### PR TITLE
Implement TransportationAnalysis study selection/area computations

### DIFF
--- a/app/models/transportation_analysis.rb
+++ b/app/models/transportation_analysis.rb
@@ -1,13 +1,29 @@
 class TransportationAnalysis < ApplicationRecord
+  before_create :compute_study_selection!, :compute_study_area!
   after_create :load_data!
-  
+
+  before_save :compute_study_area!
+
   belongs_to :project
+
+  def compute_study_selection!
+    tracts = Db::CensusTract.for_geom(project.bbls_geom)
+
+    self.jtw_study_selection = tracts
+  end
+
+  def compute_study_area!
+    union = Db::CensusTract.st_union_geoids(self.jtw_study_selection)
+    # get the centroid of union
+
+    self.jtw_study_area = union.centroid
+  end
 
   def load_data!  
     zones = Db::TrafficZone.for_geom(project.bbls_geom)
 
-    # self.multiple_zones = zones.count > 1
-    self.traffic_zone = zones.max # Currently set traffic zone to most conservative touched by study area
+    # Currently set traffic zone to most conservative touched by study area
+    self.traffic_zone = zones.max
 
     save!
   end

--- a/db/migrate/20190502185613_add_study_area_column_to_transportation_analysis.rb
+++ b/db/migrate/20190502185613_add_study_area_column_to_transportation_analysis.rb
@@ -1,0 +1,5 @@
+class AddStudyAreaColumnToTransportationAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transportation_analyses, :jtw_study_area, :geometry, limit: {:srid=>4326, :type=>"point"}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_02_162157) do
+ActiveRecord::Schema.define(version: 2019_05_02_185613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_05_02_162157) do
     t.datetime "updated_at", null: false
     t.integer "project_id"
     t.jsonb "jtw_study_selection", default: [], null: false, array: true
+    t.geometry "jtw_study_area", limit: {:srid=>4326, :type=>"st_point"}, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :project do
     name         { Faker::Address.street_name }
     bbls         { [1000477501] }
-    bbls_geom    { RGeo::Cartesian.preferred_factory(srid: 4326).parse_wkt("MULTIPOLYGON (((-74.0099084890881 40.708117924001066, -74.01022903213298 40.70775652803635, -74.01112059856906 40.708288226011604, -74.01079076752514 40.708695737776026, -74.0099084890881 40.708117924001066)))") }
+    bbls_geom    { generate(:multi_polygon) }
     build_year   { Faker::Date.between(1.year.from_now, 30.years.from_now).year }
     senior_units { Faker::Number.between(0, 50) }
     total_units  { Faker::Number.between(75, 750) }
@@ -14,5 +14,11 @@ FactoryBot.define do
     build_year   { Faker::Date.between(1.year.from_now, 30.years.from_now).year }
     senior_units { Faker::Number.between(0, 50) }
     total_units  { Faker::Number.between(75, 750) }
+  end
+
+  sequence :multi_polygon do
+    RGeo::Cartesian
+      .preferred_factory(srid: 4326)
+      .parse_wkt("MULTIPOLYGON (((-74.0099084890881 40.708117924001066, -74.01022903213298 40.70775652803635, -74.01112059856906 40.708288226011604, -74.01079076752514 40.708695737776026, -74.0099084890881 40.708117924001066)))")
   end
 end

--- a/spec/models/transportation_analysis_spec.rb
+++ b/spec/models/transportation_analysis_spec.rb
@@ -2,12 +2,17 @@ require 'rails_helper'
 
 RSpec.describe TransportationAnalysis, type: :model do    
   before do
-    @ceqr_data = class_double('TrafficZone')
-    allow(@ceqr_data).to receive(:for_geom).and_return([2])
+    @trafficZoneMock = class_double('TrafficZone')
+    allow(@trafficZoneMock).to receive(:for_geom).and_return([2])
 
-    stub_const("#{Db}::TrafficZone", @ceqr_data)
+    @censusTractMock = class_double('CensusTract')
+    allow(@censusTractMock).to receive(:for_geom).and_return(['foo'])
+    allow(@censusTractMock).to receive(:st_union_geoids).and_return(generate(:multi_polygon))
+
+    stub_const("#{Db}::TrafficZone", @trafficZoneMock)
+    stub_const("#{Db}::CensusTract", @censusTractMock)
   end
-  
+
   let(:project) { create(:project) }
   let(:analysis) { create(:transportation_analysis, project: project) }
 
@@ -17,14 +22,31 @@ RSpec.describe TransportationAnalysis, type: :model do
     end
 
     it "sets traffic zone to max if given multiple" do
-      allow(@ceqr_data).to receive(:for_geom).and_return([2, 4])
+      allow(@trafficZoneMock).to receive(:for_geom).and_return([2, 4])
       expect(analysis.traffic_zone).to be(4)
     end
+
+    it "sets study selection based on project study area" do
+      allow(@censusTractMock).to receive(:for_geom).and_return(['bar'])
+      expect(analysis.jtw_study_selection).to eq(['bar'])
+    end
+
+    it "sets the geographic centroid of the study area" do
+      expect(analysis.jtw_study_area.geometry_type).to be RGeo::Feature::Point
+    end
   end
-  
+
+  describe "#save" do
+    it "updates the study area when changing the study selection" do
+      analysis.jtw_study_selection = ['foo', 'bar']
+      analysis.save!
+      expect(analysis.jtw_study_area.geometry_type).to be RGeo::Feature::Point
+    end
+  end
+
   describe "#load_data!" do
     it "sets traffic zone if successful" do
-      allow(@ceqr_data).to receive(:for_geom).and_return([3])
+      allow(@trafficZoneMock).to receive(:for_geom).and_return([3])
 
       expect(analysis.traffic_zone).to be(3)
     end


### PR DESCRIPTION
This PR adds new functionality to the existing TransportationAnalysis model, including dependent migration for the study _area_ column, alongside tests. Depends on upcoming #289 to work in integration.