### PR TITLE
Address TransportationAnalysis migration with existing data

### DIFF
--- a/db/migrate/20190502185613_add_study_area_column_to_transportation_analysis.rb
+++ b/db/migrate/20190502185613_add_study_area_column_to_transportation_analysis.rb
@@ -1,5 +1,12 @@
 class AddStudyAreaColumnToTransportationAnalysis < ActiveRecord::Migration[5.2]
   def change
-    add_column :transportation_analyses, :jtw_study_area_centroid, :geometry, limit: {:srid=>4326, :type=>"point"}, null: false
+    add_column :transportation_analyses, :jtw_study_area_centroid, :geometry, limit: {:srid=>4326, :type=>"point"}
+
+    TransportationAnalysis.all.each do |a|
+      a.send(:compute_study_data)
+      a.save!
+    end
+
+    change_column_null :transportation_analyses, :jtw_study_area_centroid, false
   end
 end


### PR DESCRIPTION
Small adjustment to `develop` that adds logic to create `jtw_study_selection` and `jtw_study_area_centroid` for existing data.

Migration was failing on existing data because of `NOT NULL` constraint.