### PR TITLE
326 Popup fetches data about modal split for a CT

### DIFF
--- a/frontend/app/components/mapbox/current-mouse-position.js
+++ b/frontend/app/components/mapbox/current-mouse-position.js
@@ -2,12 +2,15 @@ import Component from '@ember/component';
 import { action } from '@ember-decorators/object';
 
 export default class MapboxCurrentMousePositionComponent extends Component {
-  mapboxEventName = 'mousemove';
-
   currentMapMouseEvent = null;
 
   @action
-  handleEvent(e) {
+  handleMouseMove(e) {
     this.set('currentMapMouseEvent', e);
+  }
+
+  @action
+  handleMouseLeave() {
+    this.set('currentMapMouseEvent', null);
   }
 }

--- a/frontend/app/components/throttle-property.js
+++ b/frontend/app/components/throttle-property.js
@@ -1,0 +1,34 @@
+import Component from '@ember/component';
+import { keepLatestTask } from 'ember-concurrency-decorators';
+import { timeout } from 'ember-concurrency';
+
+const DEFAULT_MS = 500;
+
+// This component takes a property, which is assumed to be bound
+// through templates, and throttles the update stream to a given
+// number of milliseconds. The throttled updates are yielded
+export default class ThrottlePropertyComponent extends Component {
+  init(...args) {
+    super.init(...args);
+
+    this.didUpdateAttributesTask.perform(); 
+  }
+
+  // bound property to throttle updates
+  property = null;
+
+  milliseconds = DEFAULT_MS;
+
+  didUpdateAttrs() {
+   this.didUpdateAttributesTask.perform(); 
+  }
+
+  @keepLatestTask({
+    maxConcurrency: 1,
+  })
+  *didUpdateAttributesTask() {
+    yield timeout(this.milliseconds);
+
+    return this.property;
+  }
+}

--- a/frontend/app/components/transportation/study-area-map/census-tract-data.js
+++ b/frontend/app/components/transportation/study-area-map/census-tract-data.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default class TransportationCensusTractDataComponent extends Component {
+}

--- a/frontend/app/models/modal-split.js
+++ b/frontend/app/models/modal-split.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+const { Model } = DS;
+import { attr } from '@ember-decorators/data';
+
+export default class DataTablesModalSplitsModel extends Model {
+  @attr('string') residential_geoid;
+  @attr('string') work_geoid;
+  @attr('string') mode;
+  @attr('number') count;
+  @attr('number') standard_error;
+}

--- a/frontend/app/templates/components/mapbox/current-mouse-position.hbs
+++ b/frontend/app/templates/components/mapbox/current-mouse-position.hbs
@@ -1,4 +1,6 @@
 {{!-- binds a map event with an action using mapbox-gl's on method --}}
-{{mapbox-gl-on this.mapboxEventName (action 'handleEvent') eventSource=map.instance}}
+{{mapbox-gl-on 'mousemove' (action 'handleMouseMove') eventSource=map.instance}}
+
+{{mapbox-gl-on 'mouseout' (action 'handleMouseLeave') eventSource=map.instance}}
 
 {{yield currentMapMouseEvent}}

--- a/frontend/app/templates/components/throttle-property.hbs
+++ b/frontend/app/templates/components/throttle-property.hbs
@@ -1,0 +1,1 @@
+{{yield didUpdateAttributesTask.lastSuccessful.value}}

--- a/frontend/app/templates/components/transportation/study-area-map/census-tract-data.hbs
+++ b/frontend/app/templates/components/transportation/study-area-map/census-tract-data.hbs
@@ -1,0 +1,5 @@
+{{#throttle-property property=geoid as |geoid|}}
+  {{#needs-async needs=(find-record 'modal-split' geoid) as |censusData|}}
+    {{yield censusData}}
+  {{/needs-async}}
+{{/throttle-property}}

--- a/frontend/app/templates/components/transportation/study-area-map/census-tract-popup.hbs
+++ b/frontend/app/templates/components/transportation/study-area-map/census-tract-popup.hbs
@@ -1,18 +1,32 @@
 {{#mapbox/current-mouse-position map=map as |mapMouseEvent|}}
   {{#mapbox/intersecting-features map=map
     point=mapMouseEvent.point
-    options=(hash layers=(array layerId)) as |features|
+    options=(hash layers=(array layerId)) as |intersectingFeatures|
   }}
-    {{#if (and mapMouseEvent.point features)}}
+    {{#if (and mapMouseEvent.point intersectingFeatures)}}
       {{#hover-card point=mapMouseEvent.point}}
         <div class="ui card">
           <div class="content">
-            <div class="header">{{features.firstObject.properties.boroname}}</div>
+            <div class="header">{{intersectingFeatures.firstObject.properties.boroname}}</div>
             <div class="meta">
-              <span>2 days ago</span>
-              <a>{{features.firstObject.properties.boroname}}</a>
+              <span>Census Tract ID: {{intersectingFeatures.firstObject.properties.geoid}}</span>
             </div>
-            <p></p>
+            <div class="description">
+              {{#transportation/study-area-map/census-tract-data
+                geoid=intersectingFeatures.firstObject.properties.geoid as |censusData|}}
+                {{#censusData.loading}}
+                  <i class="spinner icon"></i>
+                {{/censusData.loading}}
+                {{#censusData.loaded as |data|}}
+                  <div class="header">{{data.count}}</div>
+                  <div class="meta">
+                    <span>2 days ago</span>
+                    <a>{{data.mode}}</a>
+                  </div>
+                  <p></p>
+                {{/censusData.loaded}}
+              {{/transportation/study-area-map/census-tract-data}}
+            </div>
           </div>
         </div>
       {{/hover-card}}

--- a/frontend/mirage/config.js
+++ b/frontend/mirage/config.js
@@ -95,6 +95,19 @@ export default function() {
    */
   this.get('bbls');
 
+  /**
+   *
+   * BBLs
+   *
+   */
+  this.get('modal-splits/:id', function(schema, request) {
+    const record = schema.modalSplits.first();
+    const { params: { id } } = request;
+    record.id = id;
+
+    return record;
+  });
+
   // These comments are here to help you get started. Feel free to delete them.
 
   /*

--- a/frontend/mirage/factories/modal-split.js
+++ b/frontend/mirage/factories/modal-split.js
@@ -1,0 +1,9 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  residential_geoid: '1234a',
+  work_geoid: '4321b',
+  mode: 'car',
+  count: 1000,
+  standard_error: 10.5,
+});

--- a/frontend/mirage/scenarios/default.js
+++ b/frontend/mirage/scenarios/default.js
@@ -8,4 +8,5 @@ export default function(server) {
   server.create('bbl');
   server.create('project');
   server.create('user');
+  server.createList('modal-split', 20);
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "babel-eslint": "^10.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^4.0.2",
+    "ember-angle-bracket-invocation-polyfill": "1.3.1",
     "ember-auto-import": "^1.2.21",
     "ember-changeset": "^2.0.0",
     "ember-changeset-validations": "^2.0.0",
@@ -66,6 +67,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-metrics": "^0.13.0",
     "ember-moment": "^7.8.0",
+    "ember-needs-async": "0.3.0",
     "ember-page-title": "^5.0.0",
     "ember-promise-helpers": "^1.0.6",
     "ember-resolver": "^5.1.3",
@@ -80,6 +82,7 @@
     "jsonwebtoken": "8.5.1",
     "loader.js": "^4.7.0",
     "mapbox-gl": "0.54.0",
+    "pretender": "3.0.1",
     "rsvp": "^4.8.4",
     "sass": "^1.16.1",
     "semantic-ui-ember": "^3.0.0"
@@ -87,8 +90,7 @@
   "dependencies": {
     "@sentry/browser": "^4.6.3",
     "@turf/bbox": "^6.0.1",
-    "@turf/centroid": "^6.0.2",
-    "pretender": "3.0.1"
+    "@turf/centroid": "^6.0.2"
   },
   "ember-addon": {
     "paths": [

--- a/frontend/tests/integration/components/throttle-property-test.js
+++ b/frontend/tests/integration/components/throttle-property-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Component from '@ember/component';
+
+module('Integration | Component | throttle-property', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    assert.expect(3);
+    this.propertyWasUpdated = function() {
+      assert.ok(true);
+    }
+    this.propertyToThrottle = 1;
+
+    class TestComponent extends Component {
+      didUpdateAttrs() {
+        this.someAction();
+      }
+
+      someAction = () => {}
+
+      someReceivedThrottledProp = null;
+    }
+
+    this.owner.register('component:test-component', TestComponent)
+
+    await render(hbs`
+      {{#throttle-property property=propertyToThrottle milliseconds=1000 as |property|}}
+        {{test-component someReceivedThrottledProp=property someAction=(action propertyWasUpdated)}}
+      {{/throttle-property}}
+    `);
+
+    this.set('propertyToThrottle', 2);
+    this.set('propertyToThrottle', 3);
+    this.set('propertyToThrottle', 4);
+    this.set('propertyToThrottle', 5);
+    this.set('propertyToThrottle', 6);
+    this.set('propertyToThrottle', 7);
+
+    // property gets updated many more times than 3, but it throttles
+  });
+
+  test('it passes through the prop even without subsequent updates', async function(assert) {
+    this.propertyToThrottle = 1;
+
+    class TestComponent extends Component {
+      someReceivedThrottledProp = null;
+
+      layout=hbs`
+        {{someReceivedThrottledProp}}
+      `
+    }
+
+    this.owner.register('component:test-component', TestComponent)
+
+    await render(hbs`
+      {{#throttle-property property=propertyToThrottle milliseconds=1000 as |property|}}
+        {{test-component someReceivedThrottledProp=property}}
+      {{/throttle-property}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), '1')
+  });
+});

--- a/frontend/tests/integration/components/transportation/study-area-map/census-tract-data-test.js
+++ b/frontend/tests/integration/components/transportation/study-area-map/census-tract-data-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Integration | Component | transportation/study-area-map/census-tract-data', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders', async function(assert) {
+    this.server.create('modal-split', {
+      count: 9999,
+    });
+    this.geoid = 1;
+
+    await render(hbs`
+      {{#transportation/study-area-map/census-tract-data geoid=geoid as |censusTractData|}}
+        {{#censusTractData.loaded as |data|}}
+          {{data.count}}
+        {{/censusTractData.loaded}}
+      {{/transportation/study-area-map/census-tract-data}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), '9999');
+  });
+});

--- a/frontend/tests/unit/models/modal-split-test.js
+++ b/frontend/tests/unit/models/modal-split-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | modal split', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('modal-split', {});
+    assert.ok(model);
+  });
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -403,6 +403,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz#a7cc3f66119a9f7ebe2de5383cce193473d65991"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-arrow-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
@@ -591,6 +597,13 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-typescript@^7.1.0":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz#ab3351ba35307b79981993536c93ff8be050ba28"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
 
 "@babel/plugin-transform-unicode-regex@^7.2.0":
   version "7.2.0"
@@ -844,13 +857,6 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
-"@ember/render-modifiers@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.0.tgz#dc1e4c615e38507da4b6a80f6e4b27fe4d37ec8f"
-  dependencies:
-    ember-cli-babel "^7.1.2"
-    ember-modifier-manager-polyfill "^1.0.1"
-
 "@ember/test-helpers@^0.7.26":
   version "0.7.27"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.27.tgz#c622cabd0cbb95b34efc1e1b6274ab5a14edc138"
@@ -911,6 +917,10 @@
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
+
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
 
 "@glimmer/interfaces@^0.27.0":
   version "0.27.0"
@@ -1512,6 +1522,12 @@ ansi-styles@^3.0.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-to-html@^0.6.6:
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.11.tgz#5093fc4962186c0e9343dec572a4f71abdc93439"
+  dependencies:
+    entities "^1.1.1"
+
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
@@ -1973,7 +1989,7 @@ babel-plugin-filter-imports@^1.1.1:
     babel-types "^6.26.0"
     lodash "^4.17.10"
 
-babel-plugin-filter-imports@^2.0.3:
+babel-plugin-filter-imports@^2.0.3, babel-plugin-filter-imports@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-2.0.4.tgz#9209b708ed3b228349c4e6f660358bf02685e803"
   dependencies:
@@ -3396,6 +3412,12 @@ calculate-cache-key-for-tree@^1.1.0:
   dependencies:
     json-stable-stringify "^1.0.1"
 
+calculate-cache-key-for-tree@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.2.3.tgz#5a5e4fcfa2d374a63e47fe967593f179e8282825"
+  dependencies:
+    json-stable-stringify "^1.0.1"
+
 call-limit@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/call-limit/-/call-limit-1.1.0.tgz#6fd61b03f3da42a2cd0ec2b60f02bd0e71991fea"
@@ -4274,6 +4296,14 @@ ember-ajax@^4.0.2:
     ember-cli-babel "^6.16.0"
     najax "^1.0.3"
 
+ember-angle-bracket-invocation-polyfill@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.1.tgz#3dd0b91b3776a8048a943889c031fa7f9ea44ec4"
+  dependencies:
+    ember-cli-babel "^6.17.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.0.2"
+
 ember-assign-polyfill@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.4.0.tgz#acb00466f7d674b3e6b030acfe255b3b1f6472e1"
@@ -4471,7 +4501,30 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cl
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.4.2:
+ember-cli-babel@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.5.0.tgz#af654dcef23630391d2efe85aaa3bdf8b6ca17b7"
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.7.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   dependencies:
@@ -4493,29 +4546,6 @@ ember-cli-babel@^7.4.2:
     broccoli-source "^1.1.0"
     clone "^2.1.2"
     ember-cli-babel-plugin-helpers "^1.1.0"
-    ember-cli-version-checker "^2.1.2"
-    ensure-posix-path "^1.0.2"
-    semver "^5.5.0"
-
-ember-cli-babel@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.5.0.tgz#af654dcef23630391d2efe85aaa3bdf8b6ca17b7"
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-transform-modules-amd" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.2.0"
-    "@babel/polyfill" "^7.0.0"
-    "@babel/preset-env" "^7.0.0"
-    "@babel/runtime" "^7.2.0"
-    amd-name-resolver "^1.2.1"
-    babel-plugin-debug-macros "^0.3.0"
-    babel-plugin-ember-modules-api-polyfill "^2.7.0"
-    babel-plugin-module-resolver "^3.1.1"
-    broccoli-babel-transpiler "^7.1.2"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.1"
-    broccoli-source "^1.1.0"
-    clone "^2.1.2"
     ember-cli-version-checker "^2.1.2"
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
@@ -4810,6 +4840,23 @@ ember-cli-test-loader@^2.2.0:
   dependencies:
     ember-cli-babel "^6.8.1"
 
+ember-cli-typescript@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-2.0.1.tgz#9c46729213b9e1d13f5c3ff8421d772134aa889e"
+  dependencies:
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-transform-typescript" "^7.1.0"
+    ansi-to-html "^0.6.6"
+    debug "^4.0.0"
+    ember-cli-babel-plugin-helpers "^1.0.0"
+    execa "^1.0.0"
+    fs-extra "^7.0.0"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^6.0.0"
+    stagehand "^1.0.0"
+    walk-sync "^1.0.0"
+
 ember-cli-uglify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-2.1.0.tgz#4a0641fe4768d7ab7d4807aca9924cc77c544184"
@@ -4857,7 +4904,7 @@ ember-cli-version-checker@^3.0.0:
     resolve "^1.9.0"
     semver "^5.6.0"
 
-ember-cli-version-checker@^3.1.2:
+ember-cli-version-checker@^3.1.2, ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
   dependencies:
@@ -4997,6 +5044,15 @@ ember-concurrency@^0.8.27:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
+ember-concurrency@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.9.0.tgz#0016652ff780fb665842e7f47815ee0601122ea1"
+  dependencies:
+    babel-core "^6.24.1"
+    ember-cli-babel "^6.8.2"
+    ember-compatibility-helpers "^1.2.0"
+    ember-maybe-import-regenerator "^0.1.5"
+
 ember-cookies@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ember-cookies/-/ember-cookies-0.3.1.tgz#42ca530703092f6cde691103d608a6a5a58f2d76"
@@ -5009,6 +5065,37 @@ ember-copy@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
   dependencies:
     ember-cli-babel "^6.6.0"
+
+ember-data@^3.8.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.10.0.tgz#b5f53a445ba1ee37890ec672b3dc3f869d8b3992"
+  dependencies:
+    "@ember/ordered-set" "^2.0.3"
+    "@glimmer/env" "^0.1.7"
+    babel-plugin-feature-flags "^0.3.1"
+    babel-plugin-filter-imports "^2.0.4"
+    babel6-plugin-strip-class-callcheck "^6.0.0"
+    babel6-plugin-strip-heimdall "^6.0.1"
+    broccoli-debug "^0.6.5"
+    broccoli-file-creator "^2.1.1"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-rollup "^2.1.1"
+    calculate-cache-key-for-tree "^1.2.0"
+    chalk "^2.4.1"
+    ember-cli-babel "^7.7.3"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-test-info "^1.0.0"
+    ember-cli-typescript "^2.0.0"
+    ember-cli-version-checker "^3.1.3"
+    ember-inflector "^3.0.0"
+    git-repo-info "^2.0.0"
+    heimdalljs "^0.3.0"
+    inflection "^1.12.0"
+    npm-git-info "^1.0.3"
+    resolve "^1.8.1"
+    silent-error "^1.1.1"
 
 ember-data@~3.7.0:
   version "3.7.0"
@@ -5204,14 +5291,6 @@ ember-metrics@^0.13.0:
     ember-getowner-polyfill "^2.0.0"
     ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
-ember-modifier-manager-polyfill@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz#6554b70d09a7d3b80d366b72ed482fb9a3e813c0"
-  dependencies:
-    ember-cli-babel "^7.4.2"
-    ember-cli-version-checker "^2.1.2"
-    ember-compatibility-helpers "^1.2.0"
-
 ember-moment@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/ember-moment/-/ember-moment-7.8.0.tgz#12f33f786b9b8b08d7ca46314b8a59d38cc39048"
@@ -5219,6 +5298,15 @@ ember-moment@^7.8.0:
     ember-cli-babel "^6.7.2"
     ember-getowner-polyfill "^2.0.1"
     ember-macro-helpers "^1.0.0"
+
+ember-needs-async@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-needs-async/-/ember-needs-async-0.3.0.tgz#e98957a0b93be6a2603d0846d786a5676198648d"
+  dependencies:
+    ember-cli-babel "^7.1.2"
+    ember-cli-htmlbars "^3.0.0"
+    ember-concurrency "^0.9.0"
+    ember-data "^3.8.0"
 
 ember-page-title@^5.0.0:
   version "5.0.0"
@@ -5484,7 +5572,7 @@ ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz#a65b3e42d0b71cfc585eb774f9943c8d9b91b0c2"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
 
@@ -10206,7 +10294,7 @@ rsvp@^4.6.1, rsvp@^4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.2.tgz#9d5647108735784eb13418cdddb56f75b919d722"
 
-rsvp@^4.7.0, rsvp@^4.8.3, rsvp@^4.8.4:
+rsvp@^4.7.0, rsvp@^4.8.1, rsvp@^4.8.3, rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
 
@@ -10763,6 +10851,12 @@ ssri@^6.0.1:
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
   dependencies:
     figgy-pudding "^3.5.1"
+
+stagehand@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stagehand/-/stagehand-1.0.0.tgz#79515e2ad3a02c63f8720c7df9b6077ae14276d9"
+  dependencies:
+    debug "^4.1.0"
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
This PR adds some new components to the transportation map hover which lookup data.

Because we're blocked by lack for real data for these splits, these changes setup Mirage mocks, which make several assumptions about implementation of #274.

This PR also changes some internals of existing components.

![687474703a2f2f7265636f726469742e636f2f6d70306c7537686b644e2e676966](https://user-images.githubusercontent.com/5004319/58727201-ac057680-83b1-11e9-8128-08d19bf60f47.gif)
