### PR TITLE
309: Move incorrect variables from subdistrictTotals to levelTotals

### DIFF
--- a/frontend/app/components/public-schools/no-action/table-projected-enrollment.js
+++ b/frontend/app/components/public-schools/no-action/table-projected-enrollment.js
@@ -1,35 +1,4 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-import LevelTotals from '../../../fragments/public-schools/LevelTotals';
 
 export default Component.extend({
-  psTable: computed('analysis.subdistrictTotals.@each', function() {
-    return this.analysis.subdistrictTotals.filterBy('level', 'ps');
-  }),
-
-  psTableTotals: computed('analysis.subdistrictTotals.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.analysis.subdistrictTotals.filterBy('level', 'ps')
-    });
-  }),
-
-  isTable: computed('analysis.subdistrictTotals.@each', function() {
-    return this.analysis.subdistrictTotals.filterBy('level', 'is');
-  }),
-
-  isTableTotals: computed('analysis.subdistrictTotals.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.analysis.subdistrictTotals.filterBy('level', 'is')
-    });
-  }),
-
-  hsTable: computed('analysis.subdistrictTotals.@each', function() {
-    return this.analysis.subdistrictTotals.filterBy('level', 'hs');
-  }),
-
-  hsTableTotals: computed('analysis.subdistrictTotals.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.analysis.subdistrictTotals.filterBy('level', 'hs')
-    });
-  }),
 });

--- a/frontend/app/components/public-schools/summary.js
+++ b/frontend/app/components/public-schools/summary.js
@@ -3,10 +3,6 @@ import { computed } from '@ember/object';
 
 export default Component.extend({
   activeSchoolsLevel: 'ps',
-  activeSdId: null,
-  activeSd: computed('activeSdId', function() {
-    return this.analysis.subdistricts.findBy('id', parseInt(this.activeSdId));
-  }),
 
   EC_active: false,
   NA_resdev: false,
@@ -14,167 +10,16 @@ export default Component.extend({
   NA_utilchange: false,
   WA_schools: false,
 
-  didReceiveAttrs() {
-    this._super(...arguments);
-    this.set('activeSdId', (this.analysis.subdistricts[0].id).toString());
-  },
-
-  activeFutureResidentialDevelopment: computed(
-    'activeSchoolsLevel',
-    'activeSd',
-    'analysis.{dataVersion,futureResidentialDev.@each}',
-    
-    function() {      
-      if (this.activeSchoolsLevel === 'hs') {
-        return this.analysis.futureResidentialDev
-          .map(b => {
-            b.set('enrollment', b.get(`${this.activeSchoolsLevel}_students`));
-            return b;
-          });
-      } else {
-        return this.analysis.futureResidentialDev
-          .filter((b) => (b.district === this.activeSd.district && b.subdistrict === this.activeSd.subdistrict))
-          .map(b => {
-            b.set('enrollment', b.get(`${this.activeSchoolsLevel}_students`));
-            return b;
-          });
-      }
+  levelTotals: computed('activeSchoolsLevel', function() {
+    switch (this.activeSchoolsLevel) {
+      case 'ps': return this.analysis.psLevelTotals;
+      case 'is': return this.analysis.isLevelTotals;
+      case 'hs': return this.analysis.hsLevelTotals;
     }
-  ),
+  }),
 
-  activeLCMGS: computed(
-    'activeSchoolsLevel',
-    'activeSd',
-    'analysis.{dataVersion,lcgms.[]}',
-    
-    function() {
-      if (this.activeSchoolsLevel === 'hs') {
-        return this.analysis.lcgms.filterBy('level', 'hs'); 
-      } else {
-        return this.analysis.lcgms.filter(
-          (b) => (b.district === this.activeSd.district && 
-                  b.subdistrict === this.activeSd.subdistrict &&
-                  b.level === this.activeSchoolsLevel)
-        ); 
-      }
-    }
-  ),
-
-  activeScaProjects: computed(
-    'activeSchoolsLevel',
-    'activeSd',
-    'analysis.{dataVersion,scaProjects.[]}',
-    
-    function() {
-      const projects = this.analysis.scaProjects
-        .map(b => ({
-          ...b,
-          capacity: b[`${this.activeSchoolsLevel}_capacity`]
-        }));
-
-      if (this.activeSchoolsLevel === 'hs') {
-        return projects.filter((b) => b.includeInCapacity && b.capacity > 0);
-      } else {
-        return projects.filter(
-          (b) => 
-            b.district === this.activeSd.district
-            && b.subdistrict === this.activeSd.subdistrict
-            && b.includeInCapacity
-            && b.capacity > 0
-        );
-      }
-    }
-  ),
-
-  activeBuildings: computed(
-    'activeSd',
-    'activeSchoolsLevel',
-    'analysis.{dataVersion,buildings.[]}',
-    
-    function() {
-      const buildings = this.analysis.buildings.map((b) => ({
-        ...b,
-        capacityDelta: parseInt(b.capacityFuture) - parseInt(b.capacity)
-      }));
-      
-      if (this.activeSchoolsLevel === 'hs') {
-        return buildings.filter(
-          (b) => 
-            ('capacityFuture' in b)
-            && (parseInt(b.capacity) !== parseInt(b.capacityFuture))
-            && b.level === 'hs'
-        );
-      } else {
-        return buildings.filter(
-          (b) => 
-            ('capacityFuture' in b)
-            && (parseInt(b.capacity) !== parseInt(b.capacityFuture))
-            && b.district === this.activeSd.district
-            && b.subdistrict === this.activeSd.subdistrict
-            && b.level === this.activeSchoolsLevel
-        );
-      }
-    }
-  ),
-
-  activeSchoolsWithAction: computed(
-    'activeSd',
-    'activeSchoolsLevel',
-    'analysis.{dataVersion,schoolsWithAction.[]}',
-    
-    function() {
-      const schools = this.analysis.schoolsWithAction
-        .map(b => ({
-          ...b,
-          capacity: parseInt(b[`${this.activeSchoolsLevel}_seats`])
-        }))
-      
-      if (this.activeSchoolsLevel === 'hs') { 
-        return schools
-      } else {
-        return schools.filter(
-          (b) => 
-            b.district === this.activeSd.district
-            && b.subdistrict === this.activeSd.subdistrict
-        )
-      }
-    }
-  ),
-
-  existingConditions: computed(
-    'activeSdId',
-    'activeSchoolsLevel',
-    'analysis.dataVersion',
-    
-    function() {
-      if (this.activeSchoolsLevel === 'hs') {
-        return this.analysis.subdistrictTotals.findBy('level', 'hs');
-      } else {
-        return this.analysis.subdistrictTotals.find(
-          (total) => (total.id === parseInt(this.activeSdId) && total.level === this.activeSchoolsLevel)
-        );
-      }
-    }
-  ),
-
-  futureConditions: computed(
-    'activeSdId',
-    'activeSchoolsLevel',
-    'analysis.dataVersion',
-    
-    function() {
-      if (this.activeSchoolsLevel === 'hs') {
-        return this.analysis.subdistrictTotals.findBy('level', 'hs');
-      } else {
-        return this.analysis.subdistrictTotals.find(
-          (total) => (total.id === parseInt(this.activeSdId) && total.level === this.activeSchoolsLevel)
-        );
-      }
-    }
-  ),
-
-  EC_newSchoolsOpened: computed('activeSd', 'activeSchoolsLevel', 'activeLCGMS', function() {    
-    const schools = this.activeLCMGS;
+  EC_newSchoolsOpened: computed('activeSchoolsLevel', 'analysis.lcmgs', function() {    
+    const schools = this.analysis.lcgms.filterBy('level', this.activeSchoolsLevel);
 
     const enrollment = schools.mapBy('enroll').reduce((a, v) => a + parseInt(v), 0);
     const capacity   = schools.mapBy('capacity').reduce((a, v) => a + parseInt(v), 0);
@@ -182,8 +27,11 @@ export default Component.extend({
     return { enrollment, capacity, schools };
   }),
 
-  NA_newResidentialDevelopment: computed('activeSd', 'activeSchoolsLevel', 'activeFutureResidentialDevelopment.[]', function() {
-    const developments = this.activeFutureResidentialDevelopment;
+  NA_newResidentialDevelopment: computed('activeSchoolsLevel', function() {
+    const developments = this.analysis.futureResidentialDev.map(b => {
+      b.set('enrollment', b.get(`${this.activeSchoolsLevel}_students`));
+      return b;
+    });
 
     const enrollment = developments
       .mapBy(`${this.activeSchoolsLevel}_students`)
@@ -192,15 +40,31 @@ export default Component.extend({
     return { enrollment, developments }
   }),
 
-  NA_plannedSchools: computed('activeSd', 'activeSchoolsLevel', 'activeScaProjects', function() {    
-    const capacity = this.futureConditions.scaCapacityIncrease;
-    const schools = this.activeScaProjects;
+  NA_plannedSchools: computed('activeSchoolsLevel', 'levelTotals', function() {    
+    const capacity = this.levelTotals.scaCapacityIncrease;
+
+    const schools = this.analysis.scaProjects
+      .map(b => ({
+        ...b,
+        capacity: b[`${this.activeSchoolsLevel}_capacity`]
+      }))
+      .filter((b) => b.includeInCapacity && b.capacity > 0);
 
     return { capacity, schools }
   }),
 
-  NA_significantUtilChanges: computed('activeSd', 'activeSchoolsLevel', 'analysis.buildings.[]', function() {
-    const schools = this.activeBuildings;
+  NA_significantUtilChanges: computed('activeSchoolsLevel', 'analysis.buildings.[]', function() {
+    const schools = this.analysis.buildings
+      .map((b) => ({
+        ...b,
+        capacityDelta: parseInt(b.capacityFuture) - parseInt(b.capacity)
+      }))
+      .filter(
+        (b) => 
+          ('capacityFuture' in b)
+          && (parseInt(b.capacity) !== parseInt(b.capacityFuture))
+          && b.level === this.activeSchoolsLevel
+      );
     
     const capacityDelta = schools
       .reduce((a, b) => a + b.capacityDelta, 0);
@@ -208,8 +72,12 @@ export default Component.extend({
     return { capacityDelta, schools }
   }),
 
-  WA_newSchools: computed('activeSd', 'activeSchoolsLevel', 'analysis.schoolsWithAction.[]', function() {
-    const schools = this.activeSchoolsWithAction;
+  WA_newSchools: computed('activeSchoolsLevel', 'analysis.schoolsWithAction.[]', function() {
+    const schools = this.analysis.schoolsWithAction
+      .map(b => ({
+        ...b,
+        capacity: parseInt(b[`${this.activeSchoolsLevel}_seats`])
+      }));
 
     const capacity = schools
       .mapBy('capacity')
@@ -218,15 +86,7 @@ export default Component.extend({
     return { capacity, schools }
   }),
 
-  sd: computed('activeSdId', function() {
-    return this.analysis.subdistricts.findBy('id', parseInt(this.activeSdId));
-  }),
-
   actions: {
-    setSdId: function(sdId) {
-      this.set('activeSdId', sdId);
-    },
-
     toggle: function(prop) {
       this.toggleProperty(prop);
     },

--- a/frontend/app/components/public-schools/with-action/change-in-enrollment.js
+++ b/frontend/app/components/public-schools/with-action/change-in-enrollment.js
@@ -1,26 +1,4 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-import LevelTotals from '../../../fragments/public-schools/LevelTotals';
 
 export default Component.extend({
-  psTable: computed('analysis.{subdistrictTotals,schoolsWithAction}.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.get('analysis.subdistrictTotals').filterBy('level', 'ps'),
-      newSchoolSeats: this.get('analysis.schoolsWithAction').mapBy('ps_seats').reduce((a, v) => a + parseInt(v), 0)
-    });
-  }),
-
-  isTable: computed('analysis.{subdistrictTotals,schoolsWithAction}.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.get('analysis.subdistrictTotals').filterBy('level', 'is'),
-      newSchoolSeats: this.get('analysis.schoolsWithAction').mapBy('is_seats').reduce((a, v) => a + parseInt(v), 0)
-    });
-  }),
-
-  hsTable: computed('analysis.{subdistrictTotals,schoolsWithAction}.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.get('analysis.subdistrictTotals').filterBy('level', 'hs'),
-      newSchoolSeats: this.get('analysis.schoolsWithAction').mapBy('hs_seats').reduce((a, v) => a + parseInt(v), 0)
-    });
-  })
 });

--- a/frontend/app/components/public-schools/with-action/results.js
+++ b/frontend/app/components/public-schools/with-action/results.js
@@ -1,26 +1,4 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-import LevelTotals from '../../../fragments/public-schools/LevelTotals';
 
 export default Component.extend({
-  ps: computed('analysis.{subdistrictTotals,schoolsWithAction}.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.get('analysis.subdistrictTotals').filterBy('level', 'ps'),
-      newSchoolSeats: this.get('analysis.schoolsWithAction').mapBy('ps_seats').reduce((a, v) => a + parseInt(v), 0)
-    });
-  }),
-
-  is: computed('analysis.{subdistrictTotals,schoolsWithAction}.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.get('analysis.subdistrictTotals').filterBy('level', 'is'),
-      newSchoolSeats: this.get('analysis.schoolsWithAction').mapBy('is_seats').reduce((a, v) => a + parseInt(v), 0)
-    });
-  }),
-
-  hs: computed('analysis.{subdistrictTotals,schoolsWithAction}.@each', function() {
-    return LevelTotals.create({
-      subdistrictTotals: this.get('analysis.subdistrictTotals').filterBy('level', 'hs'),
-      newSchoolSeats: this.get('analysis.schoolsWithAction').mapBy('hs_seats').reduce((a, v) => a + parseInt(v), 0)
-    });
-  })
 });

--- a/frontend/app/fragments/public-schools/LevelTotals.js
+++ b/frontend/app/fragments/public-schools/LevelTotals.js
@@ -1,6 +1,8 @@
 import EmberObject from '@ember/object';
 import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import round from '../../utils/round';
+import sumOf from '../../utils/sumMapBy';
 
 /**
  * LevelTotals is an EmberObject that aggregates the output of a list of SubdistrictTotals
@@ -12,7 +14,67 @@ import round from '../../utils/round';
  */
 
 
-export default EmberObject.extend({
+export default EmberObject.extend({ 
+  // Existing Conditions
+  
+  existingConditionsEnrollment: computed('subdistrictTotals', function() {
+    return sumOf(
+      this.get('subdistrictTotals').mapBy('enrollmentTotal')
+    )
+  }),
+
+  existingConditionsCapacity: computed('subdistrictTotals', function() {
+    return sumOf(
+      this.get('subdistrictTotals').mapBy('capacityTotal')
+    )
+  }),
+
+  existingConditionsUtilization: computed(
+    'existingConditionsEnrollment',
+    'existingConditionsCapacity',
+    function() {
+      return round(this.existingConditionsEnrollment / this.existingConditionsCapacity, 4);
+    }
+  ),
+
+  existingConditionsSeats: computed('subdistrictTotals', function() {
+    return sumOf(
+      this.get('subdistrictTotals').mapBy('seatsTotal')
+    )
+  }),
+
+  // No Action
+
+  noActionEnrollment: alias('enrollNoActionTotal'),
+  noActionEnrollmentDelta: alias('enrollNoActionDeltaTotal'),
+  noActionCapacity: alias('capacityNoActionTotal'),
+  noActionCapacityDelta: computed('subdistrictTotals', function() {
+    return sumOf(
+      this.get('subdistrictTotals').mapBy('capacityNoActionDelta')
+    );
+  }),
+  noActionUtilization: alias('utilizationNoActionTotal'),
+  noActionSeats: alias('seatsNoActionTotal'),
+
+  // With Action
+
+  withActionEnrollment: alias('enrollWithActionTotal'),
+  withActionEnrollmentDelta: alias('enrollWithActionDeltaTotal'),
+  withActionCapacity: alias('capacityWithActionTotal'),
+  withActionCapacityDelta: alias('newSchoolSeats'),
+  withActionUtilization: alias('utilizationWithActionTotal'),
+  withActionSeats: alias('seatsWithActionTotal'),
+
+  // Individual Attribute Totals
+
+  scaCapacityIncrease: computed('subdistrictTotals', function() {
+    return sumOf(
+      this.get('subdistrictTotals').mapBy('scaCapacityIncrease')
+    );
+  }),  
+
+  // Older methods
+  
   enrollTotal: computed('subdistrictTotals', function() {
     return this.get('subdistrictTotals').mapBy('enroll').reduce(function(acc, value) {
       return acc + parseInt(value);

--- a/frontend/app/fragments/public-schools/LevelTotals.js
+++ b/frontend/app/fragments/public-schools/LevelTotals.js
@@ -8,7 +8,7 @@ import round from '../../utils/round';
  *
  * @constructor
  * @param {SubdistrictTotal[]} subdistrictTotals - Array of SubdistrictTotal objects filtered by relevant level
- * @param {integer} newSchoolSets - Total number of school seats for the filtered school level
+ * @param {integer} studentsWithAction - Number of students to be added by project under analysis
  */
 
 
@@ -29,7 +29,7 @@ export default EmberObject.extend({
     return this.get('enrollTotal') + this.get('studentsTotal');
   }),
 
-  enrollWithActionTotal: computed('subdistrictTotals', function() {
+  enrollWithActionTotal: computed('subdistrictTotals', function() {    
     return this.get('enrollNoActionTotal') + this.studentsWithAction;
   }),
 
@@ -51,6 +51,12 @@ export default EmberObject.extend({
 
   capacityNoActionTotal: computed('subdistrictTotals', function() {
     return this.get('subdistrictTotals').mapBy('capacityNoAction').reduce(function(acc, value) {
+      return acc + parseInt(value);
+    }, 0);
+  }),
+
+  newSchoolSeats: computed('subdistrictTotals', function() {
+    return this.get('subdistrictTotals').mapBy('newCapacityWithAction').reduce(function(acc, value) {
       return acc + parseInt(value);
     }, 0);
   }),

--- a/frontend/app/fragments/public-schools/LevelTotals.js
+++ b/frontend/app/fragments/public-schools/LevelTotals.js
@@ -5,7 +5,7 @@ import round from '../../utils/round';
 /**
  * LevelTotals is an EmberObject that aggregates the output of a list of SubdistrictTotals
  * Three LevelTotals obejcts are created per analysis, one for each school level: ps, is, hs.
- * 
+ *
  * @constructor
  * @param {SubdistrictTotal[]} subdistrictTotals - Array of SubdistrictTotal objects filtered by relevant level
  * @param {integer} newSchoolSets - Total number of school seats for the filtered school level
@@ -14,25 +14,39 @@ import round from '../../utils/round';
 
 export default EmberObject.extend({
   enrollTotal: computed('subdistrictTotals', function() {
-    return this.get('subdistrictTotals').mapBy('enroll').reduce(function(acc, value) {            
+    return this.get('subdistrictTotals').mapBy('enroll').reduce(function(acc, value) {
       return acc + parseInt(value);
     }, 0);
   }),
 
   studentsTotal: computed('subdistrictTotals', function() {
-    return this.get('subdistrictTotals').mapBy('students').reduce(function(acc, value) {            
+    return this.get('subdistrictTotals').mapBy('students').reduce(function(acc, value) {
       return acc + parseInt(value);
     }, 0);
   }),
 
-  enrollNoActionTotal: computed('projectedEnrollTotal', 'studentsTotal', function() {
+  enrollNoActionTotal: computed('enrollTotal', 'studentsTotal', function() {
     return this.get('enrollTotal') + this.get('studentsTotal');
   }),
 
   enrollWithActionTotal: computed('subdistrictTotals', function() {
-    return this.get('subdistrictTotals').mapBy('enrollWithAction').reduce(function(acc, value) {            
-      return acc + parseInt(value);
-    }, 0);
+    return this.get('enrollNoActionTotal') + this.studentsWithAction;
+  }),
+
+  enrollNoActionDeltaTotal: computed('enrollNoActionTotal', 'enrollTotal', function() {
+    return this.get('enrollNoActionTotal') - this.get('enrollTotal');
+  }),
+
+  enrollWithActionDeltaTotal: computed('enrollWithActionTotal', 'enrollTotal', function() {
+    return this.get('enrollWithActionTotal') - this.get('enrollTotal');
+  }),
+
+  enrollDifferenceTotal: computed('enrollWithActionTotal', 'enrollNoActionTotal', function() {
+    return this.get('enrollWithActionTotal') - this.get('enrollNoActionTotal');
+  }),
+
+  enrollDeltaDifferenceTotal: computed('enrollNoActionDeltaTotal', 'enrollWithActionDeltaTotal', function() {
+    return this.get('enrollWithActionDeltaTotal') - this.get('enrollNoActionDeltaTotal');
   }),
 
   capacityNoActionTotal: computed('subdistrictTotals', function() {
@@ -51,6 +65,10 @@ export default EmberObject.extend({
 
   seatsWithActionTotal: computed('subdistrictTotals', function() {
     return this.get('capacityWithActionTotal') - this.get('enrollWithActionTotal');
+  }),
+
+  seatsDifferenceTotal: computed('seatsNoActionTotal', 'seatsWithActionTotal', function() {
+    return this.get('seatsWithActionTotal') - this.get('seatsNoActionTotal');
   }),
 
   utilizationNoActionTotal: computed('enrollNoActionTotal', 'capacityNoActionTotal', function() {
@@ -74,7 +92,7 @@ export default EmberObject.extend({
   }),
 
   // Mitigation
-  mitigateSeatCount: computed('enrollWithActionTotal', 'utilizationNoActionTotal', 'capacityWithActionTotal', function() {    
+  mitigateSeatCount: computed('enrollWithActionTotal', 'utilizationNoActionTotal', 'capacityWithActionTotal', function() {
     const seatsToMitigateUtilization = this.get('enrollWithActionTotal') - (this.get('capacityWithActionTotal') - 1)
 
     const seatsToMitigateChange = Math.ceil(

--- a/frontend/app/fragments/public-schools/SubdistrictTotals.js
+++ b/frontend/app/fragments/public-schools/SubdistrictTotals.js
@@ -22,7 +22,6 @@ import round from '../../utils/round';
  * @param {integer} enroll - Future enrollment for given level, subdistrict, and build year
  * @param {integer} students - Future students from sca enrollment projections and any user-inputed future housing development
  * @param {integer} scaCapacityIncrease - Additional school seats provided by future schools (from sca capital plan) user has included in analysis
- * @param {integer} studentsWithAction - Number of students to be added by project under analysis
  * @param {integer} newCapacityWithAction - Additional school seats provided by school built with project
  *
  * @todo rename `buildings` attribut to `schools`

--- a/frontend/app/fragments/public-schools/SubdistrictTotals.js
+++ b/frontend/app/fragments/public-schools/SubdistrictTotals.js
@@ -8,23 +8,23 @@ import round from '../../utils/round';
  * It accepts a number attributes that come from the database, stored on the public-schools-analysis model.
  * A SubdistrictTotals object is created for every ps and is school, per subdistrict. And one SubdistrictTotals
  * for the borough wide hs analysis. (@todo a different object should probably exist specifically for hs analysis)
- * 
+ *
  * @constructor
  * @param {string} level - ps, is, or hs
- * 
+ *
  * @param {string} borough - Borough if level is hs
  * @param {integer} district - School district if level is ps or is
  * @param {integer} subdistrict - School subdistrict if level is ps or is
- * 
+ *
  * @param {School[]} allBuildings - Array of all Schools received from the db
- * 
+ *
  * @param {integer} studentMultiplier - Multiplier for the given level
  * @param {integer} enroll - Future enrollment for given level, subdistrict, and build year
  * @param {integer} students - Future students from sca enrollment projections and any user-inputed future housing development
  * @param {integer} scaCapacityIncrease - Additional school seats provided by future schools (from sca capital plan) user has included in analysis
  * @param {integer} studentsWithAction - Number of students to be added by project under analysis
  * @param {integer} newCapacityWithAction - Additional school seats provided by school built with project
- * 
+ *
  * @todo rename `buildings` attribut to `schools`
  * @todo experiment with typescript for calculation fragments
  */
@@ -118,21 +118,10 @@ export default EmberObject.extend({
   enrollNoActionDelta: computed('enrollNoAction', 'enrollExistingConditions', function() {
     return this.enrollNoAction - this.enrollExistingConditions;
   }),
-  enrollWithAction: computed('studentsWithAction', function() {
-    return this.enrollNoAction + this.studentsWithAction;
-  }),
-  enrollWithActionDelta: computed('enrollWithAction', 'enrollExistingConditions', function() {
-    return this.enrollWithAction - this.enrollExistingConditions;
-  }),
-  enrollDifference: computed('enrollNoAction', 'enrollWithAction', function() {
-    return this.enrollWithAction - this.enrollNoAction;
-  }),
-  enrollDeltaDifference: computed('enrollNoActionDelta', 'enrollWithActionDelta', function() {
-    return this.enrollWithActionDelta - this.enrollNoActionDelta;
-  }),
 
   capacityExisting: alias('capacityTotal'),
   capacityFuture: alias('capacityTotalNoAction'),
+
   capacityNoAction: computed('capacityFuture', 'scaCapacityIncrease', function() {
     return this.capacityFuture + this.scaCapacityIncrease;
   }),
@@ -156,30 +145,10 @@ export default EmberObject.extend({
   seatsNoAction: computed('capacityNoAction', 'enrollNoAction', function() {
     return this.capacityNoAction - this.enrollNoAction;
   }),
-  seatsWithAction: computed('capacityNoAction', 'enrollWithAction', function() {
-    return this.capacityNoAction - this.enrollWithAction;
-  }),
-  seatsDifference: computed('seatsNoAction', 'seatsWithAction', function() {
-    return this.seatsWithAction - this.seatsNoAction;
-  }),
 
 
   utilizationNoAction: computed('enrollNoAction', function() {
     return round(this.enrollNoAction / this.capacityNoAction, 3);
   }),
-  utilizationWithAction: computed('enrollWithAction', function() {
-    return round(this.enrollWithAction / this.capacityNoAction, 3);
-  }),
-  utilizationChange: computed('utilizationWithAction', 'utilizationNoAction', function() {
-    return round(this.utilizationWithAction - this.utilizationNoAction, 4);
-  }),
 
-
-  impact: computed('utilizationChange', 'utilizationWithAction', function() {
-    return (
-      (this.utilizationChange >= 0.05)
-      &&
-      (this.utilizationWithAction >= 1)
-    );
-  })
 });

--- a/frontend/app/models/public-schools-analysis.js
+++ b/frontend/app/models/public-schools-analysis.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 import { computed } from '@ember/object';
 
 import SubdistrictTotals from '../fragments/public-schools/SubdistrictTotals';
+import LevelTotals from '../fragments/public-schools/LevelTotals';
 
 export default DS.Model.extend({  
   project: DS.belongsTo('project'),
@@ -235,7 +236,6 @@ export default DS.Model.extend({
             return acc;
           }, 0),
 
-        studentsWithAction: this.estHsStudents || 0,
         newCapacityWithAction: this.schoolsWithAction.reduce(function(acc, value) {
           return acc + parseInt(value.hs_seats);
         }, 0),
@@ -279,7 +279,6 @@ export default DS.Model.extend({
             return acc;
           }, 0),
 
-          studentsWithAction: this.estEsStudents || 0,
           newCapacityWithAction: this.schoolsWithAction.filter(
             (b) => (b.district === sd.district && b.subdistrict === sd.subdistrict)
           ).reduce(function(acc, value) {
@@ -324,7 +323,6 @@ export default DS.Model.extend({
             return acc;
           }, 0),
 
-          studentsWithAction: this.estIsStudents || 0,
           newCapacityWithAction: this.schoolsWithAction.filter(
             (b) => (b.district === sd.district && b.subdistrict === sd.subdistrict)
           ).reduce(function(acc, value) {
@@ -334,6 +332,27 @@ export default DS.Model.extend({
       });
 
       return tables;
-    }
+    },
   ),
+
+  psLevelTotals: computed('{subdistrictTotals,schoolsWithAction}.@each', function() {
+    return LevelTotals.create({
+      subdistrictTotals: this.subdistrictTotals.filterBy('level', 'ps'),
+      studentsWithAction: this.estEsStudents || 0,
+    });
+  }),
+
+  isLevelTotals: computed('{subdistrictTotals,schoolsWithAction}.@each', function() {
+    return LevelTotals.create({
+      subdistrictTotals: this.subdistrictTotals.filterBy('level', 'is'),
+      studentsWithAction: this.estIsStudents || 0,
+    });
+  }),
+
+  hsLevelTotals: computed('{subdistrictTotals,schoolsWithAction}.@each', function() {
+    return LevelTotals.create({
+      subdistrictTotals: this.subdistrictTotals.filterBy('level', 'hs'),
+      studentsWithAction: this.estHsStudents || 0,
+    });
+  }),
 });

--- a/frontend/app/templates/components/public-schools/no-action/table-projected-enrollment.hbs
+++ b/frontend/app/templates/components/public-schools/no-action/table-projected-enrollment.hbs
@@ -39,160 +39,159 @@
       </th>
     </tr>
   </thead>
-  {{#if psTable}}
-    <thead>
-      <tr>
-        <th colspan="7">
-          Primary Schools
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#each psTable as |p|}}
-        <tr>
-          <td>
-            {{p.sdName}}
-          </td>
-          <td>
-            {{p.enroll}}
-          </td>
-          <td class="math--left">
-            <i class="plus circle icon"></i>
-            {{p.students}}
-          </td>
-          <td>
-            {{p.enrollNoAction}}
-          </td>
-          <td>
-            {{p.capacityNoAction}}
-          </td>
-          <td>
-            {{p.seatsNoAction}}
-          </td>
-          <td>
-            {{percentage p.utilizationNoAction}}
-          </td>
-        </tr>
-      {{/each}}
-    </tbody>
-    {{#if analysis.multiSubdistrict}}
+
+  <thead>
+    <tr>
+      <th colspan="7">
+        Primary Schools
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each analysis.psLevelTotals.subdistrictTotals as |p|}}
       <tr>
         <td>
-          <em>
-            Totals across study area
-          </em>
+          {{p.sdName}}
         </td>
         <td>
-          <em>
-            {{psTableTotals.enrollTotal}}
-          </em>
+          {{p.enroll}}
         </td>
         <td class="math--left">
           <i class="plus circle icon"></i>
-          <em>
-            {{psTableTotals.studentsTotal}}
-          </em>
+          {{p.students}}
         </td>
         <td>
-          <em>
-            {{psTableTotals.enrollNoActionTotal}}
-          </em>
+          {{p.enrollNoAction}}
         </td>
         <td>
-          <em>
-            {{psTableTotals.capacityNoActionTotal}}
-          </em>
+          {{p.capacityNoAction}}
         </td>
         <td>
-          <em>
-            {{psTableTotals.seatsNoActionTotal}}
-          </em>
+          {{p.seatsNoAction}}
         </td>
         <td>
-          <em>
-            {{percentage psTableTotals.utilizationNoActionTotal}}
-          </em>
+          {{percentage p.utilizationNoAction}}
         </td>
       </tr>
-    {{/if}}
+    {{/each}}
+  </tbody>
+  {{#if analysis.multiSubdistrict}}
+    <tr>
+      <td>
+        <em>
+          Totals across study area
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.psLevelTotals.enrollTotal}}
+        </em>
+      </td>
+      <td class="math--left">
+        <i class="plus circle icon"></i>
+        <em>
+          {{analysis.psLevelTotals.studentsTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.psLevelTotals.enrollNoActionTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.psLevelTotals.capacityNoActionTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.psLevelTotals.seatsNoActionTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{percentage analysis.psLevelTotals.utilizationNoActionTotal}}
+        </em>
+      </td>
+    </tr>
   {{/if}}
-  {{#if isTable}}
-    <thead>
-      <tr>
-        <th colspan="7">
-          Intermediate Schools
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#each isTable as |p|}}
-        <tr>
-          <td>
-            {{p.sdName}}
-          </td>
-          <td>
-            {{p.enroll}}
-          </td>
-          <td class="math--left">
-            <i class="plus circle icon"></i>
-            {{p.students}}
-          </td>
-          <td>
-            {{p.enrollNoAction}}
-          </td>
-          <td>
-            {{p.capacityNoAction}}
-          </td>
-          <td>
-            {{p.seatsNoAction}}
-          </td>
-          <td>
-            {{percentage p.utilizationNoAction}}
-          </td>
-        </tr>
-      {{/each}}
-    </tbody>
-    {{#if analysis.multiSubdistrict}}
+
+  <thead>
+    <tr>
+      <th colspan="7">
+        Intermediate Schools
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each analysis.isLevelTotals.subdistrictTotals as |p|}}
       <tr>
         <td>
-          <em>
-            Totals across study area
-          </em>
+          {{p.sdName}}
         </td>
         <td>
-          <em>
-            {{isTableTotals.enrollTotal}}
-          </em>
+          {{p.enroll}}
         </td>
         <td class="math--left">
           <i class="plus circle icon"></i>
-          <em>
-            {{isTableTotals.studentsTotal}}
-          </em>
+          {{p.students}}
         </td>
         <td>
-          <em>
-            {{isTableTotals.enrollNoActionTotal}}
-          </em>
+          {{p.enrollNoAction}}
         </td>
         <td>
-          <em>
-            {{isTableTotals.capacityNoActionTotal}}
-          </em>
+          {{p.capacityNoAction}}
         </td>
         <td>
-          <em>
-            {{isTableTotals.seatsNoActionTotal}}
-          </em>
+          {{p.seatsNoAction}}
         </td>
         <td>
-          <em>
-            {{percentage isTableTotals.utilizationNoActionTotal}}
-          </em>
+          {{percentage p.utilizationNoAction}}
         </td>
       </tr>
-    {{/if}}
+    {{/each}}
+  </tbody>
+  {{#if analysis.multiSubdistrict}}
+    <tr>
+      <td>
+        <em>
+          Totals across study area
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.isLevelTotals.enrollTotal}}
+        </em>
+      </td>
+      <td class="math--left">
+        <i class="plus circle icon"></i>
+        <em>
+          {{analysis.isLevelTotals.studentsTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.isLevelTotals.enrollNoActionTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.isLevelTotals.capacityNoActionTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{analysis.isLevelTotals.seatsNoActionTotal}}
+        </em>
+      </td>
+      <td>
+        <em>
+          {{percentage analysis.isLevelTotals.utilizationNoActionTotal}}
+        </em>
+      </td>
+    </tr>
   {{/if}}
+  
   {{#if analysis.hsAnalysis}}
     <thead>
       <tr>
@@ -202,7 +201,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each hsTable as |p|}}
+      {{#each analysis.hsLevelTotals.subdistrictTotals as |p|}}
         <tr>
           <td>
             {{analysis.borough}}

--- a/frontend/app/templates/components/public-schools/summary.hbs
+++ b/frontend/app/templates/components/public-schools/summary.hbs
@@ -126,22 +126,18 @@
         With Action
       </td>
       <td>
-        {{futureConditions.enrollWithAction}}
       </td>
       <td>
         {{futureConditions.capacityWithAction}}
       </td>
       <td>
-        {{futureConditions.enrollWithActionDelta}}
       </td>
       <td>
         {{futureConditions.capacityWithActionDelta}}
       </td>
       <td>
-        {{percentage futureConditions.utilizationWithAction}}
       </td>
       <td>
-        {{futureConditions.seatsWithAction}}
       </td>
     </tr>
   </tbody>

--- a/frontend/app/templates/components/public-schools/summary.hbs
+++ b/frontend/app/templates/components/public-schools/summary.hbs
@@ -1,18 +1,5 @@
 <div class="ui basic top attached segment">
   <div class="ui secondary menu">
-    <div class="ui simple dropdown item">
-      <strong>
-        {{sd.sdName}}
-      </strong>
-      <i class="dropdown icon"></i>
-      <div class="menu">
-        {{#each analysis.subdistricts as |sd|}}
-          <a class="item" {{action "setSdId" sd.id}}>
-            {{sd.sdName}}
-          </a>
-        {{/each}}
-      </div>
-    </div>
     <a
       class="item {{if (eq activeSchoolsLevel "ps") "active"}}"
       {{action (mut activeSchoolsLevel) "ps"}}
@@ -77,10 +64,10 @@
         Existing Conditions
       </td>
       <td>
-        {{existingConditions.enrollmentTotal}}
+        {{levelTotals.existingConditionsEnrollment}}
       </td>
       <td>
-        {{existingConditions.capacityTotal}}
+        {{levelTotals.existingConditionsCapacity}}
       </td>
       <td class="disabled">
         –
@@ -89,10 +76,10 @@
         –
       </td>
       <td>
-        {{percentage existingConditions.utilizationTotal}}
+        {{percentage levelTotals.existingConditionsUtilization}}
       </td>
       <td>
-        {{existingConditions.seatsTotal}}
+        {{levelTotals.existingConditionsSeats}}
       </td>
     </tr>
     <tr>
@@ -103,22 +90,22 @@
         No Action
       </td>
       <td>
-        {{futureConditions.enrollNoAction}}
+        {{levelTotals.noActionEnrollment}}
       </td>
       <td>
-        {{futureConditions.capacityNoAction}}
+        {{levelTotals.noActionCapacity}}
       </td>
       <td>
-        {{futureConditions.enrollNoActionDelta}}
+        {{levelTotals.noActionEnrollmentDelta}}
       </td>
       <td>
-        {{futureConditions.capacityNoActionDelta}}
+        {{levelTotals.noActionCapacityDelta}}
       </td>
       <td>
-        {{percentage futureConditions.utilizationNoAction}}
+        {{percentage levelTotals.noActionUtilization}}
       </td>
       <td>
-        {{futureConditions.seatsNoAction}}
+        {{levelTotals.noActionSeats}}
       </td>
     </tr>
     <tr>
@@ -126,18 +113,22 @@
         With Action
       </td>
       <td>
+        {{levelTotals.withActionEnrollment}}
       </td>
       <td>
-        {{futureConditions.capacityWithAction}}
+        {{levelTotals.withActionCapacity}}
       </td>
       <td>
+        {{levelTotals.withActionEnrollmentDelta}}
       </td>
       <td>
-        {{futureConditions.capacityWithActionDelta}}
+        {{levelTotals.withActionCapacityDelta}}
       </td>
       <td>
+        {{percentage levelTotals.withActionUtilization}}
       </td>
       <td>
+        {{levelTotals.withActionSeats}}
       </td>
     </tr>
   </tbody>

--- a/frontend/app/templates/components/public-schools/with-action/change-in-enrollment.hbs
+++ b/frontend/app/templates/components/public-schools/with-action/change-in-enrollment.hbs
@@ -43,7 +43,7 @@
       </th>
     </tr>
   </thead>
-  {{#if psTable}}
+  {{#if analysis.psLevelTotals}}
     <tbody>
       <tr>
         <td>
@@ -52,30 +52,30 @@
           </strong>
         </td>
         <td>
-          {{psTable.enrollNoActionTotal}}
+          {{analysis.psLevelTotals.enrollNoActionTotal}}
         </td>
         <TdHover @payload={{hash name="studentsFromDev" level="ps"}}>
           {{analysis.estEsStudents}}
         </TdHover>
         <td>
-          {{psTable.enrollWithActionTotal}}
+          {{analysis.psLevelTotals.enrollWithActionTotal}}
         </td>
         <td>
-          {{psTable.capacityWithActionTotal}}
+          {{analysis.psLevelTotals.capacityWithActionTotal}}
         </td>
         <td>
-          {{psTable.seatsWithActionTotal}}
+          {{analysis.psLevelTotals.seatsWithActionTotal}}
         </td>
         <TdHover @payload={{hash name="utilizationWithAction" level="ps"}}>
-          {{percentage psTable.utilizationWithActionTotal}}
+          {{percentage analysis.psLevelTotals.utilizationWithActionTotal}}
         </TdHover>
         <TdHover @payload={{hash name="utilizationChange" level="ps"}}>
-          {{percentage psTable.utilizationChangeTotal decimals=2}}
+          {{percentage analysis.psLevelTotals.utilizationChangeTotal decimals=2}}
         </TdHover>
       </tr>
     </tbody>
   {{/if}}
-  {{#if isTable}}
+  {{#if analysis.isLevelTotals}}
     <tbody>
       <tr>
         <td>
@@ -84,25 +84,25 @@
           </strong>
         </td>
         <td>
-          {{isTable.enrollNoActionTotal}}
+          {{analysis.isLevelTotals.enrollNoActionTotal}}
         </td>
         <TdHover @payload={{hash name="studentsFromDev" level="is"}}>
           {{analysis.estIsStudents}}
         </TdHover>
         <td>
-          {{isTable.enrollWithActionTotal}}
+          {{analysis.isLevelTotals.enrollWithActionTotal}}
         </td>
         <td>
-          {{isTable.capacityWithActionTotal}}
+          {{analysis.isLevelTotals.capacityWithActionTotal}}
         </td>
         <td>
-          {{isTable.seatsWithActionTotal}}
+          {{analysis.isLevelTotals.seatsWithActionTotal}}
         </td>
         <TdHover @payload={{hash name="utilizationWithAction" level="is"}}>
-          {{percentage isTable.utilizationWithActionTotal}}
+          {{percentage analysis.isLevelTotals.utilizationWithActionTotal}}
         </TdHover>
         <TdHover @payload={{hash name="utilizationChange" level="is"}}>
-          {{percentage isTable.utilizationChangeTotal decimals=2}}
+          {{percentage analysis.isLevelTotals.utilizationChangeTotal decimals=2}}
         </TdHover>
       </tr>
     </tbody>
@@ -116,25 +116,25 @@
           </strong>
         </td>
         <td>
-          {{hsTable.enrollNoActionTotal}}
+          {{analysis.hsLevelTotals.enrollNoActionTotal}}
         </td>
         <TdHover @payload={{hash name="studentsFromDev" level="hs"}}>
           {{analysis.estHsStudents}}
         </TdHover>
         <td>
-          {{hsTable.enrollWithActionTotal}}
+          {{analysis.hsLevelTotals.enrollWithActionTotal}}
         </td>
         <td>
-          {{hsTable.capacityWithActionTotal}}
+          {{analysis.hsLevelTotals.capacityWithActionTotal}}
         </td>
         <td>
-          {{hsTable.seatsWithActionTotal}}
+          {{analysis.hsLevelTotals.seatsWithActionTotal}}
         </td>
         <TdHover @payload={{hash name="utilizationWithAction" level="hs"}}>
-          {{percentage hsTable.utilizationWithActionTotal}}
+          {{percentage analysis.hsLevelTotals.utilizationWithActionTotal}}
         </TdHover>
         <TdHover @payload={{hash name="utilizationChange" level="hs"}}>
-          {{percentage hsTable.utilizationChangeTotal decimals=2}}
+          {{percentage analysis.hsLevelTotals.utilizationChangeTotal decimals=2}}
         </TdHover>
       </tr>
     </tbody>

--- a/frontend/app/templates/components/public-schools/with-action/results.hbs
+++ b/frontend/app/templates/components/public-schools/with-action/results.hbs
@@ -25,118 +25,117 @@
       </th>
     </tr>
   </thead>
-  {{#if ps}}
-    <tbody>
-      <tr class={{if ps.impact "negative"}}>
-        <td>
-          Primary Schools
-        </td>
-        <TdHover @payload={{hash name="utilizationWithAction" level="ps"}}>
-          {{percentage ps.utilizationWithActionTotal}}
-        </TdHover>
-        <TdHover @payload={{hash name="utilizationChange" level="ps"}}>
-          {{percentage ps.utilizationChangeTotal decimals=2}}
-        </TdHover>
-        <td>
-          {{#if ps.impact}}
-            <div
-              class="ui red label"
-              data-tooltip="Utilization with project is 100% or higher (at
-                {{percentage ps.utilizationWithActionTotal}}
-                 ) and Change in Utilization is 5% or higher (at
-                {{percentage ps.utilizationChangeTotal decimals=2}}
-                 )"
-              data-inverted
-            >
-              <i class="warning icon"></i>
-              Likely
-            </div>
-          {{else}}
-            <div
-              class="ui green label"
-              data-tooltip="Utilization with project is below 100% or change in utilization is below 5%"
-              data-inverted
-            >
-              <i class="check icon"></i>
-              No
-            </div>
-          {{/if}}
-        </td>
-        <td>
-          {{if ps.impact ps.mitigateSeatCount "n/a"}}
-        </td>
-        <td>
-          {{if ps.impact ps.mitigateUnitCount "n/a"}}
-        </td>
-      </tr>
-    </tbody>
-  {{/if}}
-  {{#if is}}
-    <tbody>
-      <tr class={{if is.impact "negative"}}>
-        <td>
-          Intermediate Schools
-        </td>
-        <TdHover @payload={{hash name="utilizationWithAction" level="is"}}>
-          {{percentage is.utilizationWithActionTotal}}
-        </TdHover>
-        <TdHover @payload={{hash name="utilizationChange" level="is"}}>
-          {{percentage is.utilizationChangeTotal decimals=2}}
-        </TdHover>
-        <td>
-          {{#if is.impact}}
-            <div
-              class="ui red label"
-              data-tooltip="Utilization with project is 100% or higher (at
-                {{percentage is.utilizationWithActionTotal}}
-                 ) and Change in Utilization is 5% or higher (at
-                {{percentage is.utilizationChangeTotal decimals=2}}
-                 )"
-              data-inverted
-            >
-              <i class="warning icon"></i>
-              Likely
-            </div>
-          {{else}}
-            <div
-              class="ui green label"
-              data-tooltip="Utilization with project is below 100% or change in utilization is below 5%"
-              data-inverted
-            >
-              <i class="check icon"></i>
-              No
-            </div>
-          {{/if}}
-        </td>
-        <td>
-          {{if is.impact is.mitigateSeatCount "n/a"}}
-        </td>
-        <td>
-          {{if is.impact is.mitigateUnitCount "n/a"}}
-        </td>
-      </tr>
-    </tbody>
-  {{/if}}
+ 
+  <tbody>
+    <tr class={{if analysis.psLevelTotals.impact "negative"}}>
+      <td>
+        Primary Schools
+      </td>
+      <TdHover @payload={{hash name="utilizationWithAction" level="analysis.psLevelTotals"}}>
+        {{percentage analysis.psLevelTotals.utilizationWithActionTotal}}
+      </TdHover>
+      <TdHover @payload={{hash name="utilizationChange" level="analysis.psLevelTotals"}}>
+        {{percentage analysis.psLevelTotals.utilizationChangeTotal decimals=2}}
+      </TdHover>
+      <td>
+        {{#if analysis.psLevelTotals.impact}}
+          <div
+            class="ui red label"
+            data-tooltip="Utilization with project is 100% or higher (at
+              {{percentage analysis.psLevelTotals.utilizationWithActionTotal}}
+                ) and Change in Utilization is 5% or higher (at
+              {{percentage analysis.psLevelTotals.utilizationChangeTotal decimals=2}}
+                )"
+            data-inverted
+          >
+            <i class="warning icon"></i>
+            Likely
+          </div>
+        {{else}}
+          <div
+            class="ui green label"
+            data-tooltip="Utilization with project is below 100% or change in utilization is below 5%"
+            data-inverted
+          >
+            <i class="check icon"></i>
+            No
+          </div>
+        {{/if}}
+      </td>
+      <td>
+        {{if analysis.psLevelTotals.impact analysis.psLevelTotals.mitigateSeatCount "n/a"}}
+      </td>
+      <td>
+        {{if analysis.psLevelTotals.impact analysis.psLevelTotals.mitigateUnitCount "n/a"}}
+      </td>
+    </tr>
+  </tbody>
+
+  <tbody>
+    <tr class={{if analysis.isLevelTotals.impact "negative"}}>
+      <td>
+        Intermediate Schools
+      </td>
+      <TdHover @payload={{hash name="utilizationWithAction" level="is"}}>
+        {{percentage analysis.isLevelTotals.utilizationWithActionTotal}}
+      </TdHover>
+      <TdHover @payload={{hash name="utilizationChange" level="is"}}>
+        {{percentage analysis.isLevelTotals.utilizationChangeTotal decimals=2}}
+      </TdHover>
+      <td>
+        {{#if analysis.isLevelTotals.impact}}
+          <div
+            class="ui red label"
+            data-tooltip="Utilization with project is 100% or higher (at
+              {{percentage analysis.isLevelTotals.utilizationWithActionTotal}}
+                ) and Change in Utilization is 5% or higher (at
+              {{percentage analysis.isLevelTotals.utilizationChangeTotal decimals=2}}
+                )"
+            data-inverted
+          >
+            <i class="warning icon"></i>
+            Likely
+          </div>
+        {{else}}
+          <div
+            class="ui green label"
+            data-tooltip="Utilization with project is below 100% or change in utilization is below 5%"
+            data-inverted
+          >
+            <i class="check icon"></i>
+            No
+          </div>
+        {{/if}}
+      </td>
+      <td>
+        {{if analysis.isLevelTotals.impact analysis.isLevelTotals.mitigateSeatCount "n/a"}}
+      </td>
+      <td>
+        {{if analysis.isLevelTotals.impact analysis.isLevelTotals.mitigateUnitCount "n/a"}}
+      </td>
+    </tr>
+  </tbody>
+
   {{#if analysis.hsAnalysis}}
     <tbody>
-      <tr class={{if hs.impact "negative"}}>
+      <tr class={{if analysis.hsLevelTotals.impact "negative"}}>
         <td>
           High Schools
         </td>
         <TdHover @payload={{hash name="utilizationWithAction" level="hs"}}>
-          {{percentage hs.utilizationWithActionTotal}}
+          {{percentage analysis.hsLevelTotals.utilizationWithActionTotal}}
         </TdHover>
         <TdHover @payload={{hash name="utilizationChange" level="hs"}}>
-          {{percentage hs.utilizationChangeTotal decimals=2}}
+          {{percentage analysis.hsLevelTotals.utilizationChangeTotal decimals=2}}
         </TdHover>
         <td>
-          {{#if hs.impact}}
+          {{#if analysis.hsLevelTotals.impact}}
             <div
               class="ui red label"
               data-tooltip="Utilization with project is 100% or higher (at
-                {{percentage hs.utilizationWithActionTotal}}
+                {{percentage analysis.hsLevelTotals.utilizationWithActionTotal}}
                  ) and Change in Utilization is 5% or higher (at
-                {{percentage hs.utilizationChangeTotal decimals=2}}
+                {{percentage analysis.hsLevelTotals.utilizationChangeTotal decimals=2}}
                  )"
               data-inverted
             >
@@ -155,10 +154,10 @@
           {{/if}}
         </td>
         <td>
-          {{if hs.impact hs.mitigateSeatCount "n/a"}}
+          {{if analysis.hsLevelTotals.impact analysis.hsLevelTotals.mitigateSeatCount "n/a"}}
         </td>
         <td>
-          {{if hs.impact hs.mitigateUnitCount "n/a"}}
+          {{if analysis.hsLevelTotals.impact analysis.hsLevelTotals.mitigateUnitCount "n/a"}}
         </td>
       </tr>
     </tbody>

--- a/frontend/app/templates/project/show/public-schools/with-action/scenario.hbs
+++ b/frontend/app/templates/project/show/public-schools/with-action/scenario.hbs
@@ -3,19 +3,19 @@
     <PublicSchools::StudentsGenerated
       @project={{project}}
       @analysis={{model.publicSchoolsAnalysis}}
-     />
+    />
 
   </div>
   <div class="sixteen wide column">
     <PublicSchools::WithAction::ChangeInEnrollment
       @analysis={{model.publicSchoolsAnalysis}}
-     />
+    />
 
   </div>
   <div class="sixteen wide column">
     <PublicSchools::WithAction::Results
       @analysis={{model.publicSchoolsAnalysis}}
-     />
+    />
 
   </div>
 </div>

--- a/frontend/app/utils/sumMapBy.js
+++ b/frontend/app/utils/sumMapBy.js
@@ -1,0 +1,6 @@
+export default function sumMapBy(array) {
+  return array.reduce((acc, value) => {
+    if (value === undefined) return acc;
+    return acc + parseInt(value);
+  }, 0);
+}

--- a/frontend/mirage/factories/public-schools-analysis.js
+++ b/frontend/mirage/factories/public-schools-analysis.js
@@ -337,7 +337,14 @@ export default Factory.extend({
       subdistrict: 2
     }
   ],
-  subdistrictsFromUser: () => [],
+  subdistrictsFromUser: () => [
+    {
+      id: 171,
+      sdName: "District 17 - Subdistrict 1",
+      district: 17,
+      subdistrict: 1
+    }
+  ],
   bluebook: () => [
     {
       x: 997684,
@@ -364,7 +371,7 @@ export default Factory.extend({
       hs_capacity: 0,
       ms_capacity: 669,
       ps_capacity: 0,
-      subdistrict: 2,
+      subdistrict: 1,
       capacityFuture: 669,
       the_geom_webmercator: "0101000020110F0000E42C33224F675FC19D6ADE0878ED5241"
     },
@@ -393,7 +400,7 @@ export default Factory.extend({
       hs_capacity: 0,
       ms_capacity: 1320,
       ps_capacity: 0,
-      subdistrict: 2,
+      subdistrict: 1,
       capacityFuture: 1320,
       the_geom_webmercator: "0101000020110F000094EDF05E0D675FC18ADCF21497EE5241"
     },
@@ -422,7 +429,7 @@ export default Factory.extend({
       hs_capacity: 0,
       ms_capacity: 0,
       ps_capacity: 675,
-      subdistrict: 2,
+      subdistrict: 1,
       capacityFuture: 675,
       the_geom_webmercator: "0101000020110F00007A773D1E0B665FC1DC5E1F4749EE5241"
     },
@@ -451,7 +458,7 @@ export default Factory.extend({
       hs_capacity: 0,
       ms_capacity: 0,
       ps_capacity: 724,
-      subdistrict: 2,
+      subdistrict: 1,
       capacityFuture: 724,
       the_geom_webmercator: "0101000020110F0000259E75378B675FC11423610873ED5241"
     },
@@ -480,7 +487,7 @@ export default Factory.extend({
       hs_capacity: 0,
       ms_capacity: 0,
       ps_capacity: 383,
-      subdistrict: 2,
+      subdistrict: 1,
       capacityFuture: 383,
       the_geom_webmercator: "0101000020110F00002E23569B07675FC155F9F0D5E6EE5241"
     },
@@ -5038,7 +5045,46 @@ export default Factory.extend({
       the_geom_webmercator: "0101000020110F000002FD5E0159635FC17991CEBC15F35241"
     }
   ],
-  lcgms: () => [],
+  lcgms: () => [
+    {
+      "name": "P.S. 583",
+      "level": "ps",
+      "enroll": 115,
+      "grades": "K - 05",
+      "org_id": "X583",
+      "source": "lcgms",
+      "address": "1028 WHITE PLAINS ROAD",
+      "bldg_id": "X317",
+      "capacity": "",
+      "district": 17,
+      "the_geom": "0101000020E6100000ADDC0BCC0A7752C0FAEB1516DC694440",
+      "hs_enroll": 0,
+      "is_enroll": 0,
+      "org_level": "PS",
+      "ps_enroll": 115,
+      "cartodb_id": 4,
+      "subdistrict": 2
+    },
+    {
+      "name": "P.S. 553",
+      "level": "ps",
+      "enroll": 155,
+      "grades": "K - 05",
+      "org_id": "X583",
+      "source": "lcgms",
+      "address": "1028 WHITE PLAINS ROAD",
+      "bldg_id": "X317",
+      "capacity": "",
+      "district": 17,
+      "the_geom": "0101000020E6100000ADDC0BCC0A7752C0FAEB1516DC694440",
+      "hs_enroll": 0,
+      "is_enroll": 0,
+      "org_level": "PS",
+      "ps_enroll": 155,
+      "cartodb_id": 6,
+      "subdistrict": 1
+    }
+  ],
   scaProjects: () => [],
   doeUtilChanges: () => [
     {
@@ -6600,6 +6646,24 @@ export default Factory.extend({
       multiplier: 0.582024949124332,
       subdistrict: 2,
       the_geom_webmercator: null
+    },
+    {
+      level: "PS",
+      district: 17,
+      the_geom: null,
+      cartodb_id: 94,
+      multiplier: 0.483266818664257,
+      subdistrict: 1,
+      the_geom_webmercator: null
+    },
+    {
+      level: "MS",
+      district: 17,
+      the_geom: null,
+      cartodb_id: 97,
+      multiplier: 0.682024949124332,
+      subdistrict: 1,
+      the_geom_webmercator: null
     }
   ],
   futureEnrollmentNewHousing: () => [
@@ -6614,6 +6678,18 @@ export default Factory.extend({
       district: 17,
       students: 323,
       subdistrict: 2
+    },
+    {
+      level: "PS",
+      district: 17,
+      students: 938,
+      subdistrict: 1
+    },
+    {
+      level: "MS",
+      district: 17,
+      students: 223,
+      subdistrict: 1
     }
   ],
 });

--- a/frontend/tests/unit/fragments/public-schools/level-totals-test.js
+++ b/frontend/tests/unit/fragments/public-schools/level-totals-test.js
@@ -49,19 +49,49 @@ module('Unit | Fragment | LevelTotals', function(hooks) {
   });
 
   test('#enrollWithActionTotal is calculated correctly', function(assert) {
-    let subdistrict_totals =
-    SubdistrictTotals.create({
-      enrollWithActionTotal: 400
-    });
-
     let level_totals =
     LevelTotals.create({
-      subdistrictTotals: subdistrict_totals,
+      studentsWithAction: 100,
+      enrollNoActionTotal: 300,
     });
 
-    assert.equal(level_totals.subdistrictTotals.enrollWithActionTotal, 400);
+    assert.equal(level_totals.enrollWithActionTotal, 400);
 
   });
+
+  test('#enrollWithActionDeltaTotal is calculated correctly', function(assert) {
+    let level_totals =
+    LevelTotals.create({
+      enrollTotal: 100,
+      enrollWithActionTotal: 300,
+    });
+
+    assert.equal(level_totals.enrollWithActionDeltaTotal, 200);
+
+  });
+
+  test('#enrollDifferenceTotal is calculated correctly', function(assert) {
+    let level_totals =
+    LevelTotals.create({
+      enrollWithActionTotal: 400,
+      enrollNoActionTotal: 300,
+    });
+
+    assert.equal(level_totals.enrollDifferenceTotal, 100);
+
+  });
+
+  test('#enrollDeltaDifferenceTotal is calculated correctly', function(assert) {
+    let level_totals =
+    LevelTotals.create({
+      enrollNoActionDeltaTotal: 300,
+      enrollWithActionDeltaTotal: 500,
+    });
+
+    assert.equal(level_totals.enrollDeltaDifferenceTotal, 200);
+
+  });
+
 
   test('#capacityNoActionTotal is calculated correctly', function(assert) {
     let subdistrict_totals =
@@ -108,6 +138,16 @@ module('Unit | Fragment | LevelTotals', function(hooks) {
     });
 
     assert.equal(level_totals.seatsWithActionTotal, 100);
+
+  });
+
+  test('#seatsDifferenceTotal is calculated correctly', function(assert) {
+    let level_totals = LevelTotals.create({
+      seatsWithActionTotal: 400,
+      seatsNoActionTotal: 200
+    });
+
+    assert.equal(level_totals.seatsDifferenceTotal, 200);
 
   });
 

--- a/frontend/tests/unit/fragments/public-schools/subdistrict-totals-test.js
+++ b/frontend/tests/unit/fragments/public-schools/subdistrict-totals-test.js
@@ -6,7 +6,7 @@ import School from 'labs-ceqr/fragments/public-schools/School';
 
 module('Unit | Fragment | SubdistrictTotals', function(hooks) {
   setupTest(hooks);
-  
+
   test('#buildings returns correct filters list', function(assert) {
     let schools =  [
       School.create({
@@ -288,46 +288,6 @@ test('#capacityTotal returns correct calculation', function(assert) {
 
   });
 
-  test('#enrollWithAction is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      enrollNoAction: 400,
-      studentsWithAction: 200
-    });
-
-    assert.equal(aggregate_totals.enrollWithAction, 600);
-
-  });
-
-  test('#enrollWithActionDelta is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      enrollWithAction: 400,
-      enrollExistingConditions: 200
-    });
-
-    assert.equal(aggregate_totals.enrollWithActionDelta, 200);
-
-  });
-
-  test('#enrollDifference is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      enrollWithAction: 400,
-      enrollNoAction: 200
-    });
-
-    assert.equal(aggregate_totals.enrollDifference, 200);
-
-  });
-
-  test('#enrollDeltaDifference is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      enrollWithActionDelta: 400,
-      enrollNoActionDelta: 200
-    });
-
-    assert.equal(aggregate_totals.enrollDeltaDifference, 200);
-
-  });
-
   test('#capacityNoAction is calculated correctly', function(assert) {
     let aggregate_totals = SubdistrictTotals.create({
       capacityFuture: 400,
@@ -398,26 +358,6 @@ test('#capacityTotal returns correct calculation', function(assert) {
 
   });
 
-  test('#seatsWithAction is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      capacityNoAction: 400,
-      enrollWithAction: 200
-    });
-
-    assert.equal(aggregate_totals.seatsWithAction, 200);
-
-  });
-
-  test('#seatsDifference is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      seatsWithAction: 400,
-      seatsNoAction: 200
-    });
-
-    assert.equal(aggregate_totals.seatsDifference, 200);
-
-  });
-
   test('#utilizationNoAction is calculated correctly', function(assert) {
     let aggregate_totals = SubdistrictTotals.create({
       enrollNoAction: 177,
@@ -428,34 +368,4 @@ test('#capacityTotal returns correct calculation', function(assert) {
 
   });
 
-  test('#utilizationWithAction is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      enrollWithAction: 177,
-      capacityNoAction: 181
-    });
-
-    assert.equal(aggregate_totals.utilizationWithAction, 0.978);
-
-  });
-
-  test('#utilizationChange is calculated correctly', function(assert) {
-    let aggregate_totals = SubdistrictTotals.create({
-      utilizationWithAction: 100.44444,
-      utilizationNoAction: 50.33333
-    });
-
-    assert.equal(aggregate_totals.utilizationChange, 50.1111);
-
-  });
-
-  test('#impact is calculated correctly', function(assert) {
-    let aggregate_totals =
-    SubdistrictTotals.create({
-      utilizationChange: 1,
-      utilizationWithAction: 0.8
-    });
-
-    assert.equal(aggregate_totals.impact, false);
-
-  });
 });


### PR DESCRIPTION
`enrollWithAction` was being incorrectly calculated for `subdistrictTotals` as `enrollNoAction + studentsWithAction`. `studentsWithAction` is a level-based (NOT a subdistrict-based) variable whereas `enrollNoAction` is subdistrict (and level)-based, so this was causing a bug in any calculations that incorporated `enrollWithAction`. 

In order to fix this, all of these calculations were edited and moved to `levelTotals.js`. 

The variables in `subdistrictsTotals` that were deleted:

- `enrollWithAction`
- `enrollWithActionDelta`
- `enrollDifference`
- `enrollDeltaDifference`
- `seatsWithAction`
- `seatsDifference`
- `utilizationWithAction`
- `utilizationChange`
- `impact`

The variables in `levelTotals` that were added:

- `enrollWithActionTotal` was changed
- `enrollNoActionDeltaTotal`
- `enrollWithActionDeltaTotal`
- `enrollDifferenceTotal`
- `enrollDeltaDifferenceTotal`
- `seatsDifferenceTotal`

TODO: A new PR will be created to add comments for every variable in `public-schools-analysis`