### PR TITLE
279: Implements requiredJtwStudySelection census tracts

### DIFF
--- a/backend/app/models/transportation_analysis.rb
+++ b/backend/app/models/transportation_analysis.rb
@@ -12,22 +12,22 @@ class TransportationAnalysis < ApplicationRecord
 
   private
     # Find and set the intersecting Census Tracts
-    def compute_study_selection
+    def compute_required_study_selection
       tracts = Db::CensusTract.for_geom(project.bbls_geom)
 
-      self.jtw_study_selection = tracts
+      self.required_jtw_study_selection = tracts || []
     end
 
     # Find and set the centroid
     def compute_study_area
-      centroid = Db::CensusTract.st_union_geoids_centroid(self.jtw_study_selection)
+      centroid = Db::CensusTract.st_union_geoids_centroid(self.required_jtw_study_selection)
 
       self.jtw_study_area_centroid = centroid
     end
 
     # Call necessary methods for computing study selection & area
     def compute_study_data
-      compute_study_selection
+      compute_required_study_selection
       compute_study_area
     end
 

--- a/backend/app/resources/api/v1/transportation_analysis_resource.rb
+++ b/backend/app/resources/api/v1/transportation_analysis_resource.rb
@@ -1,7 +1,8 @@
 class Api::V1::TransportationAnalysisResource < JSONAPI::Resource
   attributes(
     :traffic_zone,
-    :jtw_study_selection
+    :jtw_study_selection,
+    :required_jtw_study_selection
   )
 
   has_one :project

--- a/backend/db/migrate/20190610181704_add_required_jtw_study_selection_to_transportation_analysis.rb
+++ b/backend/db/migrate/20190610181704_add_required_jtw_study_selection_to_transportation_analysis.rb
@@ -1,0 +1,14 @@
+class AddRequiredJtwStudySelectionToTransportationAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transportation_analyses, :required_jtw_study_selection, 'varchar(11)', default: [], array: true
+    TransportationAnalysis.all.each do |a|
+      a.send(:compute_required_study_selection)
+      a.save!
+    end
+    change_column_null :transportation_analyses, :required_jtw_study_selection, false
+
+    # also, recreate the jtw_study_selection column as varchar(11)[] type
+    remove_column :transportation_analyses, :jtw_study_selection
+    add_column :transportation_analyses, :jtw_study_selection, 'varchar(11)', default: [], array: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_174747) do
+ActiveRecord::Schema.define(version: 2019_06_10_181704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -99,8 +99,9 @@ ActiveRecord::Schema.define(version: 2019_05_16_174747) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "project_id"
-    t.jsonb "jtw_study_selection", default: [], null: false, array: true
     t.geometry "jtw_study_area_centroid", limit: {:srid=>4326, :type=>"st_point"}, null: false
+    t.string "required_jtw_study_selection", limit: 11, default: [], null: false, array: true
+    t.string "jtw_study_selection", limit: 11, default: [], array: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/backend/spec/models/transportation_analysis_spec.rb
+++ b/backend/spec/models/transportation_analysis_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TransportationAnalysis, type: :model do
 
     it "sets study selection based on project study area" do
       allow(@censusTractMock).to receive(:for_geom).and_return(['bar'])
-      expect(analysis.jtw_study_selection).to eq(['bar'])
+      expect(analysis.required_jtw_study_selection).to eq(['bar'])
     end
 
     it "sets the geographic centroid of the study area" do

--- a/frontend/app/components/transportation/study-area-map.js
+++ b/frontend/app/components/transportation/study-area-map.js
@@ -1,17 +1,42 @@
 import Component from '@ember/component';
-import { action } from '@ember-decorators/object';
+import { computed, action } from '@ember-decorators/object';
 
 export default class TransportationProjectMapComponent extends Component {
   /**
    * The transportation-analysis Model, passed down from the project/show/transportation-analysis controller
    */
   analysis = {};
+
+  /**
+   * The identifier (geoid) of the currenlty hovered feature in the map
+   */
   hoveredFeatureId = null;
 
+  /**
+   * Sets hoveredFeatureId to geoid of the first feature in features array argument
+   */
   @action
   setFirstHoveredFeatureId(features){
-    if(features && features.length && (features[0] != null)){
+    if(features && features.length && features[0]){
       this.set('hoveredFeatureId', features[0].properties.geoid);
+    } else {
+      this.set('hoveredFeatureId', null);
     }
+  }
+
+    /**
+   * The composite array of all highlighted features, including:
+   * - currently hovered feature
+   * - user-selected study selection features
+   * - required study selection features
+   * which is passed to the highlight layer's FeatureFilterer
+   */
+  @computed('hoveredFeatureId', 'analysis.{jtwStudySelection.[],requiredJtwStudySelection.[]}')
+  get highlightedFeatureIds() {
+    const { hoveredFeatureId } = this;
+    const selectedFeatures = this.get('analysis.jtwStudySelection') || [];
+    const requiredSelectedFeatures = this.get('analysis.requiredJtwStudySelection') || [];
+
+    return [hoveredFeatureId, ...selectedFeatures, ...requiredSelectedFeatures];
   }
 }

--- a/frontend/app/models/transportation-analysis.js
+++ b/frontend/app/models/transportation-analysis.js
@@ -9,7 +9,10 @@ export default class TransportationAnalysisModel extends Model {
 
   // Attributes
   @attr('number') trafficZone;
-  @attr() jtwStudySelection;
+  // the geoids of REQUIRED census tracts in study selection; determined by bbl intersect
+  @attr({defaultValue: () => []}) requiredJtwStudySelection;
+  // the geoids of additional user-defined study selection
+  @attr({defaultValue: () => []}) jtwStudySelection;
 
   // Detailed Analysis trigger
   @computed(

--- a/frontend/app/templates/components/transportation/study-area-map.hbs
+++ b/frontend/app/templates/components/transportation/study-area-map.hbs
@@ -46,6 +46,7 @@
           @analysis={{analysis}} />
       </Mapbox::FeatureSelector>
     </carto-source.layer>
+
     <carto-source.layer
       @id="tracts-highlight"
       @sql="select * from nyc_census_tracts_2010"
@@ -61,9 +62,10 @@
         @map={{map}}
         @layerId={{layer.layerId}}
         @filterById="geoid"
-        @featureIds={{array this.hoveredFeatureId}}
+        @featureIds={{this.highlightedFeatureIds}}
       />
     </carto-source.layer>
+
     <carto-source.layer
       @id="subway"
       @sql="select * from mta_subway_routes_v0"

--- a/frontend/app/templates/project/show/transportation/existing-conditions.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions.hbs
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::StudyAreaMap
-      @analysis={{analysis}}
+      @analysis={{model.transportationAnalysis}}
     />
   </div>
 </div>

--- a/frontend/mirage/factories/transportation-analysis.js
+++ b/frontend/mirage/factories/transportation-analysis.js
@@ -2,7 +2,8 @@ import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   trafficZone: 2,
-  jtwStudySelection: () => [
-      "36061020300"
-  ],
+  jtwStudySelection: () => [],
+  requiredJtwStudySelection: () => [
+    "36061020300"
+  ]
 });

--- a/frontend/tests/integration/components/transportation/study-area-map-test.js
+++ b/frontend/tests/integration/components/transportation/study-area-map-test.js
@@ -6,6 +6,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Component from '@ember/component';
 import { registerEventHandler, simulateEvent }  from '../../../helpers/mapbox/mapbox-stub-helpers';
 
+const renderedGeoId = '1';
 const DEFAULT_MAPBOX_GL_INSTANCE = {
   addSource: () => {},
   addLayer: () => {},
@@ -34,7 +35,7 @@ module('Integration | Component | transportation/study-area-map', function(hooks
         return [{
           type: 'Feature',
           properties: {
-            geoid: 'test',
+            geoid: renderedGeoId,
           },
         }]
       },
@@ -42,8 +43,8 @@ module('Integration | Component | transportation/study-area-map', function(hooks
         this.filters[layerId] = filter;
       },
       // On render, component templates like `current-map-position.js`
-      // will associate action handlers to fired mouse events and 
-      // mantain a list of these associations. 
+      // will associate action handlers to fired mouse events and
+      // mantain a list of these associations.
       // We simulate this association list locally (with the `events` object)
       // so that we can make ad hoc calls to action handlers. See comment below
       // in `it hovers, displays information`.
@@ -90,16 +91,16 @@ module('Integration | Component | transportation/study-area-map', function(hooks
     assert.ok(find("[data-test-popup='census-tract']"));
   });
 
-  test('it selected features on click', async function(assert) {
+  test('it selects features on click', async function(assert) {
     // If a project exists with a transportation analysis
     const project = server.create('project');
     this.model = await this.owner.lookup('service:store')
       .findRecord('project', project.id, { include: 'transportation-analysis'});
 
-    const geoid = 'test';
+    const geoid = renderedGeoId;
 
     await render(hbs`{{transportation/study-area-map analysis=model.transportationAnalysis}}`);
-    simulateEvent(this.events, 'click', {point: 'test'});
+    simulateEvent(this.events, 'click', {point: 'point'});
 
     await settled();
 

--- a/frontend/tests/integration/components/transportation/study-area-map/study-selection-toggler-test.js
+++ b/frontend/tests/integration/components/transportation/study-area-map/study-selection-toggler-test.js
@@ -31,26 +31,25 @@ module('Integration | Component | transportation/study-area-map/study-selection-
   });
 
   test('it removes a selected feature geoId from the analysis model study selection', async function(assert) {
-    // If a project exists with a transportation analysis
+    // If a project exists with a transportation analysis with jtwStudySelection including given geoid
     const project = server.create('project');
     this.model = await this.owner.lookup('service:store')
       .findRecord('project', project.id, { include: 'transportation-analysis'});
 
-    const existingStudySelection = await this.get('model.transportationAnalysis.jtwStudySelection');
-    const existingLength = existingStudySelection.length;
-    const existingGeoid = existingStudySelection[0];
+    const geoid = 'geoid';
+    this.model.set('transportationAnalysis.jtwStudySelection', [geoid]);
 
-     // When a feature with geoid already in study selection is selected
+     // When a feature with given geoid is selected
     await render(hbs`
       {{transportation/study-area-map/study-selection-toggler analysis=model.transportationAnalysis selectedFeatureArray=selectedFeatures}}
     `);
-    this.set('selectedFeatures', [{ properties: { geoid: existingGeoid } }]);
+    this.set('selectedFeatures', [{ properties: { geoid: geoid } }]);
     await settled();
 
     // Then the geoid should be removed from the transportationAnalysis study selection
     const updatedStudySelection = await this.get('model.transportationAnalysis.jtwStudySelection');
-    assert.equal(updatedStudySelection.length, existingLength - 1)
-    assert.notOk(updatedStudySelection.includes(existingGeoid));
+    assert.equal(updatedStudySelection.length, 0)
+    assert.notOk(updatedStudySelection.includes(geoid));
   });
 
 });

--- a/frontend/tests/unit/components/transportation/study-area-map-test.js
+++ b/frontend/tests/unit/components/transportation/study-area-map-test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Unit | Component | transportation/study-area-map', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('it computes correct highlightedFeatureIds', async function(assert) {
+    // if project exists with transportationAnalysis with the given study selection id arrays
+    const jtwStudySelection = ['selectedGeoid1', 'selectedGeoid2'];
+    const requiredJtwStudySelection = ['requiredGeoid1', 'requiredGeoid2'];
+    const project = server.create('project');
+    const model = await this.owner.lookup('service:store')
+      .findRecord('project', project.id, { include: 'transportation-analysis'});
+    model.set('transportationAnalysis.jtwStudySelection', jtwStudySelection);
+    model.set('transportationAnalysis.requiredJtwStudySelection', requiredJtwStudySelection);
+
+    // when the component is rendered with that project, and has the given hovered feature id
+    let component = this.owner.factoryFor('component:transportation/study-area-map').create({analysis: model.transportationAnalysis});
+    const hoveredGeoid = 'hoveredGeoid';
+    component.setFirstHoveredFeatureId([{ properties: { geoid: hoveredGeoid } }])
+
+    // then the component's highlightedFeatureIds property should include:
+    const highlightedFeatureIds = component.get('highlightedFeatureIds');
+    // all of the requiredJtwStudySelection ids
+    assert.ok(requiredJtwStudySelection.every(id => highlightedFeatureIds.includes(id)));
+    // all of the jtwStudySelection ids
+    assert.ok(jtwStudySelection.every(id => highlightedFeatureIds.includes(id)));
+    // the hovered id
+    assert.ok(highlightedFeatureIds.includes(hoveredGeoid));
+  });
+});


### PR DESCRIPTION
- Adds a property to the transportation analysis model, `requiredJtwStudySelection`, which now gets updated on project.save() instead of `jtwStudySelection` (previously, this backend re-calculation on save was rendering all updates from the frontend no-ops, so this is a bug fix)
- In the migration, also recreates the `jtwStudySelection` property to a varchar(11) array instead of jsonb array to avoid unnecessary string escaping etc.
- Updates study-area-map to filter for required and selected geoms from `requiredJtwStudySelection` and `jtwStudySelection` in addition to `hoveredFeatureId`
- Removes use of `analysis` property from the project/show/transportation controller as argument to the `study-area-map` component rendered in the project/show/transportation/existing-conditions template, which wasn't working and was giving the map null instead of the analysis model


TODO: differentiate required census tracts in study selection from selected tracts via map styles?
