### PR TITLE
352: Remove references to deprecated ceqr_data schemas

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -24,29 +24,29 @@ if DataPackage.find_by_name("November 2017").nil?
         minYear: 2016,
         maxYear: 2017
       },
-      "ps_school_zones": { table: "school_zones.ps_2018" },
-      "is_school_zones": { table: "school_zones.is_2018" },
-      "hs_school_zones": { table: "school_zones.hs_2018" },
+      "ps_school_zones": { table: "doe_school_zones_ps.2018" },
+      "is_school_zones": { table: "doe_school_zones_is.2018" },
+      "hs_school_zones": { table: "doe_school_zones_hs.2018" },
       "enrollment_pct_by_sd": { table: "sca_enrollment_pct_by_sd.2017" },
       "housing_pipeline_by_boro": {
         minYear: 2016,
         maxYear: 2025,
-        table: "sca_housing_pipeline.boro_2017"
+        table: "sca_housing_pipeline_by_boro.2017"
       },
       "housing_pipeline_by_sd": {
         minYear: 2016,
         maxYear: 2025,
-        table: "sca_housing_pipeline.sd_2017"
+        table: "sca_housing_pipeline_by_sd.2017"
       },
       "enrollment_projection_by_boro": {
         minYear: 2015,
         maxYear: 2025,
-        table: "sca_enrollment_projections.boro_2017"
+        table: "sca_enrollment_projections_by_boro.2017"
       },
       "enrollment_projection_by_sd": {
         minYear: 2015,
         maxYear: 2025,
-        table: "sca_enrollment_projections.sd_2017"
+        table: "sca_enrollment_projections_by_sd.2017"
       },
       "significant_utilization_changes": {
         table: "doe_significant_utilization_changes.062018",
@@ -92,29 +92,29 @@ if DataPackage.find_by_name("November 2018").nil?
         minYear: 2017,
         maxYear: 2018
       },
-      "ps_school_zones": { table: "school_zones.ps_2018" },
-      "is_school_zones": { table: "school_zones.is_2018" },
-      "hs_school_zones": { table: "school_zones.hs_2018" },
+      "ps_school_zones": { table: "doe_school_zones_ps.2018" },
+      "is_school_zones": { table: "doe_school_zones_is.2018" },
+      "hs_school_zones": { table: "doe_school_zones_hs.2018" },
       "enrollment_pct_by_sd": { table: "sca_enrollment_pct_by_sd.2018" },
       "housing_pipeline_by_boro": {
         minYear: 2018,
         maxYear: 2027,
-        table: "sca_housing_pipeline.boro_2018"
+        table: "sca_housing_pipeline_by_boro.2018"
       },
       "housing_pipeline_by_sd": {
         minYear: 2018,
         maxYear: 2027,
-        table: "sca_housing_pipeline.sd_2018"
+        table: "sca_housing_pipeline_by_sd.2018"
       },
       "enrollment_projection_by_boro": {
         minYear: 2017,
         maxYear: 2027,
-        table: "sca_enrollment_projections.boro_2018"
+        table: "sca_enrollment_projections_by_boro.2018"
       },
       "enrollment_projection_by_sd": {
         minYear: 2017,
         maxYear: 2027,
-        table: "sca_enrollment_projections.sd_2018"
+        table: "sca_enrollment_projections_by_sd.2018"
       },
       "significant_utilization_changes": {
         table: "doe_significant_utilization_changes.062018",

--- a/backend/spec/models/db/enrollment_projection_spec.rb
+++ b/backend/spec/models/db/enrollment_projection_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Db::EnrollmentProjection", type: :model do
         expect(db.school_year).to be_a String
       end
       
-      it "sd_2017" do
-        tests_version("sd_2017")
+      it "2017" do
+        tests_version("2017")
       end
 
-      it "sd_2018" do
-        tests_version("sd_2018")
+      it "2018" do
+        tests_version("2018")
       end
     end
 
@@ -32,12 +32,12 @@ RSpec.describe "Db::EnrollmentProjection", type: :model do
         expect(db.year).to be_a String
       end
       
-      it "boro_2017" do
-        tests_version("boro_2017")
+      it "2017" do
+        tests_version("2017")
       end
 
-      it "boro_2018" do
-        tests_version("boro_2018")
+      it "2018" do
+        tests_version("2018")
       end
     end
   end

--- a/backend/spec/models/db/housing_pipeline_spec.rb
+++ b/backend/spec/models/db/housing_pipeline_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Db::HousingPipeline", type: :model do
         expect(db.org_level).to be_a String
       end
       
-      it "sd_2017" do
-        tests_version("sd_2017")
+      it "2017" do
+        tests_version("2017")
       end
 
-      it "sd_2018" do
-        tests_version("sd_2018")
+      it "2018" do
+        tests_version("2018")
       end
     end
 
@@ -32,12 +32,12 @@ RSpec.describe "Db::HousingPipeline", type: :model do
         expect(db.borocode).to be_an Integer
       end
       
-      it "boro_2017" do
-        tests_version("boro_2017")
+      it "2017" do
+        tests_version("2017")
       end
 
-      it "boro_2018" do
-        tests_version("boro_2018")
+      it "2018" do
+        tests_version("2018")
       end
     end
   end  


### PR DESCRIPTION
Made some changes to the structure of `ceqr_data`. This PR brings the code in alignment with the new schemas.

After merge todo:
- [ ] Delete old schemas and tables from `ceqr_data`. Note: tests will fail on any branch of code that doesn't include this PR once data is deleted.