### PR TITLE
379: Adds transit-zones and land-use layers to transportation study-area-map

### DIFF
--- a/frontend/app/components/transportation/census-tracts-map.js
+++ b/frontend/app/components/transportation/census-tracts-map.js
@@ -26,6 +26,16 @@ export default class TransportationCensusTractsMapComponent extends Component {
   hoveredFeatureId = null;
 
   /**
+   * Flag for optionally displaying transit zones
+   */
+  showTransitZones = false;
+
+  /**
+   * Flag for optionally displaying land use
+   */
+  showLandUse = false;
+
+  /**
    * Sets hoveredFeatureId to geoid of the first feature in features array argument
    */
   @action

--- a/frontend/app/components/transportation/census-tracts-map/features.js
+++ b/frontend/app/components/transportation/census-tracts-map/features.js
@@ -1,0 +1,32 @@
+import Component from '@ember/component';
+
+export default class TransportationCensusTractsMapFeaturesComponent extends Component {
+  /**
+   * Flag for optionally displaying transit zones
+   */
+  showTransitZones = false;
+
+  /**
+   * Flag for optionally displaying land use
+   */
+  showLandUse = false;
+
+  /**
+   * Lookup hash of descriptions for land use types for map legend
+   */
+  landUseDescriptionsLookup = {
+    '01': '1 & 2 Family',
+    '02': 'Multifamily Walk-up',
+    '03': 'Multifamily Elevator',
+    '04': 'Mixed Res. & Commercial',
+    '05': 'Commercial & Office',
+    '06': 'Industrial & Manufacturing',
+    '07': 'Transportation & Utility',
+    '08': 'Public Facilities & Institutions',
+    '09': 'Open Space & Outdoor Recreation',
+    '10': 'Parking Facilities',
+    '11': 'Vacant Land',
+    '00': 'Other'
+  };
+}
+

--- a/frontend/app/helpers/get-color-style.js
+++ b/frontend/app/helpers/get-color-style.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/template';
+
+/**
+ * Returns an html-safe CSS color style attribute string for a given color string.
+ * Mostly exists to get rid of an ember warning about binding style attributes.
+ */
+export function getColorStyle(params/*, hash*/) {
+  const [color] = params;
+  return htmlSafe(`color:${color}`);
+}
+
+export default helper(getColorStyle);

--- a/frontend/app/helpers/get-layer-category-colors.js
+++ b/frontend/app/helpers/get-layer-category-colors.js
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+import { colors } from 'labs-ceqr/layer-styles';
+
+/**
+ * Returns the colors for a given layer's styles as an iterable array of
+ * category/color objects (to be used for formatting map legend).
+ */
+export function getLayerCategoryColors(params/*, hash*/) {
+  const [layer] = params;
+  return  colors[layer] ? Object.keys(colors[layer]).map(category => {
+    return {category, color: colors[layer][category] }
+  }) : [];
+}
+
+export default helper(getLayerCategoryColors);

--- a/frontend/app/helpers/get-layer-colors.js
+++ b/frontend/app/helpers/get-layer-colors.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+import { colors } from 'labs-ceqr/layer-styles';
+
+export function getLayerColors(params/*, hash*/) {
+  const [layer] = params;
+  return colors[layer] || {};
+}
+
+export default helper(getLayerColors);

--- a/frontend/app/layer-styles/index.js
+++ b/frontend/app/layer-styles/index.js
@@ -1,9 +1,20 @@
 import { subwayStyles } from 'labs-ceqr/layer-styles/subway';
-import { selectableFeatureStyles } from 'labs-ceqr/layer-styles/selectable-feature';
-import { projectBblStyles } from 'labs-ceqr/layer-styles/project-bbl';
+import { selectableFeatureStyles, selectableFeatureColors } from 'labs-ceqr/layer-styles/selectable-feature';
+import { projectBblStyles, projectBblColors } from 'labs-ceqr/layer-styles/project-bbl';
+import { transitZoneStyles, transitZoneColors } from 'labs-ceqr/layer-styles/transit-zone';
+import { landUseStyles, landUseColors } from 'labs-ceqr/layer-styles/land-use';
 
 export const styles  = {
   ...subwayStyles,
   ...selectableFeatureStyles,
   ...projectBblStyles,
+  ...transitZoneStyles,
+  ...landUseStyles,
+};
+
+export const colors = {
+  'transit-zone': transitZoneColors,
+  'land-use': landUseColors,
+  'selectable-features': selectableFeatureColors,
+  'project-bbls': projectBblColors,
 };

--- a/frontend/app/layer-styles/land-use.js
+++ b/frontend/app/layer-styles/land-use.js
@@ -1,0 +1,38 @@
+export const landUseColors = {
+  '01': '#f4f455',
+  '02': '#f7d496',
+  '03': '#FF9900',
+  '04': '#f7cabf',
+  '05': '#ea6661',
+  '06': '#d36ff4',
+  '07': '#dac0e8',
+  '08': '#5CA2D1',
+  '09': '#8ece7c',
+  '10': '#bab8b6',
+  '11': '#5f5f60',
+};
+
+export const landUseStyles = {
+  'land-use': {
+    paint: {
+      'fill-opacity': 1,
+      'fill-color': {
+        property: 'landuse',
+        type: 'categorical',
+        stops: [
+          ['01', landUseColors['01']],
+          ['02', landUseColors['02']],
+          ['03', landUseColors['03']],
+          ['04', landUseColors['04']],
+          ['05', landUseColors['05']],
+          ['06', landUseColors['06']],
+          ['07', landUseColors['07']],
+          ['08', landUseColors['08']],
+          ['09', landUseColors['09']],
+          ['10', landUseColors['10']],
+          ['11', landUseColors['11']],
+        ],
+      },
+    },
+  },
+};

--- a/frontend/app/layer-styles/project-bbl.js
+++ b/frontend/app/layer-styles/project-bbl.js
@@ -1,9 +1,13 @@
+export const projectBblColors = {
+  'line': '#d7191c',
+};
+
 export const projectBblStyles = {
   'bbls': {
     paint: {
-      'line-color': '#d7191c',
+      'line-color': projectBblColors['line'],
       'line-width': 4,
-      'line-blur': 1,    
+      'line-blur': 1,
     },
   },
 };

--- a/frontend/app/layer-styles/selectable-feature.js
+++ b/frontend/app/layer-styles/selectable-feature.js
@@ -1,3 +1,9 @@
+export const selectableFeatureColors = {
+  'selected-fill-bold': 'rgba(59, 101, 216, 0.8)',
+  'selected-fill-light': 'rgba(59, 101, 216, 0.4)',
+  'selected-line': 'black',
+};
+
 export const selectableFeatureStyles = {
   'selectable-feature-content': {
     paint: {
@@ -34,19 +40,17 @@ export const selectableFeatureStyles = {
   },
   'selectable-feature-selected-fill-bold': {
     paint: {
-      'fill-color': 'rgba(59, 101, 216, 1)',
-      'fill-opacity': 0.8,
+      'fill-color': selectableFeatureColors['selected-fill-bold'],
     },
   },
   'selectable-feature-selected-fill-light': {
     paint: {
-      'fill-color': 'rgba(59, 101, 216, 1)',
-      'fill-opacity': 0.4,
+      'fill-color': selectableFeatureColors['selected-fill-light'],
     },
   },
   'selectable-feature-selected-line': {
     paint: {
-      'line-color': 'black',
+      'line-color': selectableFeatureColors['selected-line'],
       'line-opacity': 0.5,
       'line-width': {
         stops: [

--- a/frontend/app/layer-styles/transit-zone.js
+++ b/frontend/app/layer-styles/transit-zone.js
@@ -1,0 +1,25 @@
+export const transitZoneColors = {
+  '1': '#ffffb2',
+  '2': '#fecc5c',
+  '3': '#fd8d3c',
+  '4': '#f03b20',
+  '5': '#bd0026',
+};
+
+export const transitZoneStyles = {
+  'transit-zones-fill': {
+    paint: {
+      'fill-color': {
+        property: 'zone',
+        type: 'categorical',
+        stops: [
+          ['1', transitZoneColors['1']],
+          ['2', transitZoneColors['2']],
+          ['3', transitZoneColors['3']],
+          ['4', transitZoneColors['4']],
+          ['5', transitZoneColors['5']],
+        ],
+      },
+    },
+  },
+};

--- a/frontend/app/templates/components/transportation/census-tracts-map.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-map.hbs
@@ -7,6 +7,11 @@
     center=this.project.transportationAnalysis.jtwStudyAreaCentroid
   }} as |map|
 >
+  <Transportation::CensusTractsMap::Features
+    @showTransitZones={{this.showTransitZones}}
+    @showLandUse={{this.showLandUse}}
+  />
+
   <MapboxGlSource
     @sourceId='bbls_geojson'
     @map={{map.instance}}
@@ -22,6 +27,26 @@
   </MapboxGlSource>
 
   <Mapbox::CartoVectorSource @sourceId="carto" @map={{map}} as |carto-source|>
+    <carto-source.layer
+      @id='transit-zones-fill'
+      @sql='SELECT * from ceqr_data_traffic_zones_2019'
+      @layer={{hash
+        type='fill'
+        layout=(hash visibility=(if this.showTransitZones 'visible' 'none'))
+        paint=(get-layer-style 'transit-zones-fill' 'paint')
+      }}
+    />
+
+    <carto-source.layer
+      @id='land-use'
+      @sql='SELECT cartodb_id, the_geom, the_geom_webmercator, landuse FROM mappluto'
+      @layer={{hash
+        type='fill'
+        layout=(hash visibility=(if this.showLandUse 'visible' 'none'))
+        paint=(get-layer-style 'land-use' 'paint')
+      }}
+    />
+
 
     <carto-source.layer
       @id="subway-routes"

--- a/frontend/app/templates/components/transportation/census-tracts-map/features.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-map/features.hbs
@@ -1,0 +1,55 @@
+<div class="map-ui">
+  <div data-test-tz-checkbox class="transit-zone-dropdown">
+    <UiCheckbox
+      @label="Show Transit Zones"
+      @checked={{showTransitZones}}
+      @onChange={{action (mut showTransitZones)}}
+    />
+  </div>
+  <div data-test-lu-checkbox class="land-use-dropdown">
+    <UiCheckbox
+      @label="Show Land Use"
+      @checked={{showLandUse}}
+      @onChange={{action (mut showLandUse)}}
+    />
+  </div>
+</div>
+
+<div class="map-legend">
+  <div class="ui list">
+    {{#let (get-layer-colors 'project-bbls') as |projectBblsColors|}}
+    <div data-test-default-legend-item class="item">
+      <i class="square outline icon" style={{get-color-style (get projectBblsColors 'line')}}></i>
+      <div class="content">Project BBLs</div>
+    </div>
+    {{/let}}
+    {{#let (get-layer-colors 'selectable-features') as |selectableFeatureColors|}}
+    <div data-test-default-legend-item class="item">
+      <i class="square icon" style={{get-color-style (get selectableFeatureColors 'selected-fill-light')}}></i>
+      <div class="content">Selected Census Tracts</div>
+    </div>
+    <div data-test-default-legend-item class="item">
+      <i class="square icon" style={{get-color-style (get selectableFeatureColors 'selected-fill-bold')}}></i>
+      <div class="content">Required Census Tracts</div>
+    </div>
+    {{/let}}
+    {{#if showTransitZones}}
+      <div class="ui divider" style="margin: 0.5rem 0rem"></div>
+      {{#each (get-layer-category-colors 'transit-zone') as |categoryColor|}}
+        <div data-test-tz-legend-item class="item">
+          <i class="square icon" style={{get-color-style (get categoryColor 'color')}}></i>
+          <div class="content">Transit Zone {{get categoryColor 'category'}}</div>
+        </div>
+      {{/each}}
+    {{/if}}
+    {{#if showLandUse}}
+      <div class="ui divider" style="margin: 0.5rem 0rem"></div>
+      {{#each (get-layer-category-colors 'land-use') as |categoryColor|}}
+        <div data-test-lu-legend-item class="item">
+          <i class="square icon" style={{get-color-style (get categoryColor 'color')}}></i>
+          <div class="content">{{get landUseDescriptionsLookup (get categoryColor 'category')}}</div>
+        </div>
+      {{/each}}
+    {{/if}}
+  </div>
+</div>

--- a/frontend/tests/integration/components/transportation/census-tracts-map/features-test.js
+++ b/frontend/tests/integration/components/transportation/census-tracts-map/features-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { findAll, find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { landUseColors } from 'labs-ceqr/layer-styles/land-use';
+import { transitZoneColors } from 'labs-ceqr/layer-styles/transit-zone';
+
+module('Integration | Component | transportation/census-tracts-map/features', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it has default legend and unchecked boxed when flags are flase', async function(assert) {
+    // If default (false) show land-use and show transit-zone flags are used
+    // When the component is rendered
+    await render(hbs`{{transportation/census-tracts-map/features }}`);
+
+    // Then the checkboxes are not checked
+    assert.notOk(find('[data-test-tz-checkbox] .checked'));
+    assert.notOk(find('[data-text-lu-checkbox] .checked'));
+
+    // And the default items are displayed
+    assert.equal(findAll('[data-test-default-legend-item]').length, 3);
+
+    // And the transit zone and lande use items are not displayed
+    assert.equal(findAll('[data-test-tz-legend-item]').length, 0);
+    assert.equal(findAll('[data-test-lu-legend-item]').length, 0);
+  });
+
+  test('it has populated legend and checked boxed when flags are true', async function(assert) {
+    // If show land-use and show transit-zone flags are true
+    this.showLU = true;
+    this.showTZ = true;
+
+    // When the component is rendered
+    await render(hbs`{{transportation/census-tracts-map/features showLandUse=showLU showTransitZones=showTZ}}`);
+
+    // Then the checkboxes are checked
+    assert.ok(find('[data-test-tz-checkbox] .checked'));
+    assert.ok(find('[data-test-lu-checkbox] .checked'));
+    // And the legend items are displayed
+    assert.equal(findAll('[data-test-tz-legend-item]').length, Object.keys(transitZoneColors).length);
+    assert.equal(findAll('[data-test-lu-legend-item]').length, Object.keys(landUseColors).length);
+  });
+
+});

--- a/frontend/tests/integration/helpers/get-color-style-test.js
+++ b/frontend/tests/integration/helpers/get-color-style-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | get-color-style', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns a color style attribute string', async function(assert) {
+    this.set('color', '#000000');
+
+    await render(hbs`{{get-color-style color}}`);
+
+    assert.equal(this.element.textContent.trim(), `color:${this.color}`);
+  });
+});

--- a/frontend/tests/unit/helpers/get-layer-category-colors-test.js
+++ b/frontend/tests/unit/helpers/get-layer-category-colors-test.js
@@ -1,0 +1,22 @@
+import { getLayerCategoryColors } from 'labs-ceqr/helpers/get-layer-category-colors';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | get layer category colors', function() {
+  test('it returns an array of category/color objects for land-use', function(assert) {
+    const categoryColors = getLayerCategoryColors(['land-use']);
+    assert.ok(Array.isArray(categoryColors));
+    assert.ok(categoryColors.every((cc => cc.category && cc.color)));
+  });
+
+  test('it returns an array of category/color objects for transit-zone', function(assert) {
+    const categoryColors = getLayerCategoryColors(['transit-zone']);
+    assert.ok(Array.isArray(categoryColors));
+    assert.ok(categoryColors.every((cc => cc.category && cc.color)));
+  });
+
+  test('it returns an empty array if the layer does not have category colors', function(assert) {
+    const categoryColors = getLayerCategoryColors(['colorless-layer']);
+    assert.ok(Array.isArray(categoryColors));
+    assert.equal(categoryColors, 0);
+  });
+});

--- a/frontend/tests/unit/helpers/get-layer-colors-test.js
+++ b/frontend/tests/unit/helpers/get-layer-colors-test.js
@@ -1,0 +1,20 @@
+import { getLayerColors } from 'labs-ceqr/helpers/get-layer-colors';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | get layer colors', function() {
+  test('it returns a dict of colors for selectable-features', function(assert) {
+    const layerColors = getLayerColors(['selectable-features']);
+    assert.ok(layerColors instanceof Object);
+  });
+
+  test('it returns a dict of colors for project-bbls', function(assert) {
+    const layerColors = getLayerColors(['project-bbls']);
+    assert.ok(layerColors instanceof Object);
+  });
+
+  test('it returns an empty dict if the layer does not have colors', function(assert) {
+    const layerColors = getLayerColors(['colorless-layer']);
+    assert.ok(layerColors instanceof Object);
+    assert.equal(Object.keys(layerColors).length, 0);
+  });
+})


### PR DESCRIPTION
### Overview
This PR adds two layers to the transportation study-area-map that are toggle-able with checkboxes:
- transit-zones
- land-use
Default visibility for these layers is 'none'

Additionally, adds a may legend which displays features from base layers, as well as the features from toggled layers when they are visible.

### Entrypoint
`frontend/app/components/transportation/study-area-map.js` and `frontend/app/templates/transportation/study-area-map.hbs`

### Notes
The layers added by this PR seem to make carto performance even worse. The full map _never_ rendered while testing. So I don't think we should merge this PR until carto performance is back up to normal levels. 