### PR TITLE
patch to pass analysis to map component

### DIFF
--- a/frontend/app/templates/project/show/transportation/existing-conditions/journey-to-work/map.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/journey-to-work/map.hbs
@@ -1,5 +1,5 @@
 <div class="sixteen wide column">
   <Transportation::JtwMap
-    @analysis={{analysis}}
+    @analysis={{this.project.transportationAnalysis}}
   />
 </div>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/study-area/map.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/study-area/map.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::StudyAreaMap
-      @analysis={{analysis}}
+      @analysis={{this.project.transportationAnalysis}}
     />
   </div>
 </div>

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/journey-to-work-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/journey-to-work-test.js
@@ -8,4 +8,10 @@ module('Unit | Route | project/show/transportation/existing-conditions/journey-t
     let route = this.owner.lookup('route:project/show/transportation/existing-conditions/journey-to-work');
     assert.ok(route);
   });
+
+  test('it is bound to the project controller', function(assert) {
+    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/journey-to-work');
+    assert.equal(route.controllerName, 'project');
+  });
+
 });

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/study-area-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/study-area-test.js
@@ -8,4 +8,10 @@ module('Unit | Route | project/show/transportation/existing-conditions/study-are
     let route = this.owner.lookup('route:project/show/transportation/existing-conditions/study-area');
     assert.ok(route);
   });
+
+  test('it is bound to the project controller', function(assert) {
+    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/study-area');
+    assert.equal(route.controllerName, 'project');
+  });
+
 });


### PR DESCRIPTION
Quick fix and basic tests for passing analysis down to the map component.

I think we should perhaps rework how all templates and controllers access the project model. 

Questions/TODO: 
I also tried to test that the Project controller has a "project" property, but it doesn't seem to work with Ember's paradigm.

Wondering if there is a good way to test that the project/show/transportation/existing-conditions/<study-area/journey-to-work> route renders okay. 

