### PR TITLE
372: Add adjacent census tracts as default study selection

### DIFF
--- a/backend/app/models/attributes/lng_lat.rb
+++ b/backend/app/models/attributes/lng_lat.rb
@@ -1,0 +1,11 @@
+class Attributes::LngLat < ActiveRecord::ConnectionAdapters::PostGIS::OID::Spatial
+  def deserialize(value)
+    point = cast_value(value)
+    to_lng_lat(point) if point
+  end
+
+  private
+  def to_lng_lat(point)
+    [point.x, point.y]
+  end
+end

--- a/backend/app/models/db/census_tract.rb
+++ b/backend/app/models/db/census_tract.rb
@@ -8,4 +8,9 @@ class Db::CensusTract < DataRecord
   def self.for_geom(geom)
     select('DISTINCT geoid').where("ST_Intersects(ST_GeomFromText('#{geom.as_text}', #{geom.srid}), geom)").map &:geoid
   end
+
+  def self.touches_geoids(geoids)
+    selectionGeom = select("ST_MULTI(ST_UNION(geom))").where(geoid: geoids).first.st_multi
+    select("geoid").where("ST_TOUCHES(ST_GeomFromText('#{selectionGeom.as_text}', #{selectionGeom.srid}), geom)").map &:geoid
+  end
 end

--- a/backend/app/models/project.rb
+++ b/backend/app/models/project.rb
@@ -48,6 +48,6 @@ class Project < ApplicationRecord
 
   def refresh_analyses!
     # analysis models should know what they need to do to refresh
-    transportation_analysis.load_data! if saved_change_to_bbls?
+    transportation_analysis.compute_for_updated_bbls! if saved_change_to_bbls?
   end
 end

--- a/backend/app/models/transportation_analysis.rb
+++ b/backend/app/models/transportation_analysis.rb
@@ -1,43 +1,59 @@
 class TransportationAnalysis < ApplicationRecord
-  before_save :compute_study_data
+  before_save :compute_for_model_update
 
-  after_create :compute_traffic_zone!
+  before_create :compute_for_project_create_or_update
 
   belongs_to :project
 
-  # loads all necessary data by calling ! methods which imply a save
-  def load_data!
-    compute_traffic_zone!
+  # This is a workaround for a lot of fancy inititalization that the activerecord-postgis-adapter does
+  # for the attribute types it defines. 'ActiveRecord::ConnectionAdapters::PostGIS::OID::Spatial' is extended
+  # in model/attributes/lng_lat.rb
+  attribute :jtw_study_area_centroid, Attributes::LngLat.new('', 'geometry(Point,4326)')
+
+  def compute_for_updated_bbls!
+    compute_for_project_create_or_update
+    save!
   end
 
   private
     # Find and set the intersecting Census Tracts
     def compute_required_study_selection
       tracts = Db::CensusTract.for_geom(project.bbls_geom)
-
       self.required_jtw_study_selection = tracts || []
     end
 
     # Find and set the centroid
-    def compute_study_area
-      centroid = Db::CensusTract.st_union_geoids_centroid(self.required_jtw_study_selection)
-
+    def compute_study_area_centroid
+      geoids = self.required_jtw_study_selection + self.jtw_study_selection
+      centroid = Db::CensusTract.st_union_geoids_centroid(geoids)
       self.jtw_study_area_centroid = centroid
     end
 
-    # Call necessary methods for computing study selection & area
-    def compute_study_data
-      compute_required_study_selection
-      compute_study_area
+    # Find and set the adjacent Census Tracts as initial study selection
+    def compute_initial_study_selection
+      tracts = Db::CensusTract.touches_geoids(self.required_jtw_study_selection)
+      self.jtw_study_selection = tracts || []
     end
 
     # Find, set, and save the traffic zone
-    def compute_traffic_zone!
+    def compute_traffic_zone
       zones = Db::TrafficZone.for_geom(project.bbls_geom)
 
       # Currently set traffic zone to most conservative touched by study area
       self.traffic_zone = zones.max
+    end
 
-      save!
+    # Call methods to compute data that needs to be refreshed when the model is updated
+    def compute_for_model_update
+      compute_study_area_centroid
+    end
+
+    # Call methods to compute data that needs to be refreshed when model's owning project
+    # is updated (or at analysis creation)
+    def compute_for_project_create_or_update
+      compute_traffic_zone
+      compute_required_study_selection
+      compute_initial_study_selection
+      compute_study_area_centroid
     end
 end

--- a/backend/app/resources/api/v1/transportation_analysis_resource.rb
+++ b/backend/app/resources/api/v1/transportation_analysis_resource.rb
@@ -2,8 +2,10 @@ class Api::V1::TransportationAnalysisResource < JSONAPI::Resource
   attributes(
     :traffic_zone,
     :jtw_study_selection,
-    :required_jtw_study_selection
+    :required_jtw_study_selection,
+    :jtw_study_area_centroid
   )
 
   has_one :project
+
 end

--- a/backend/spec/models/project_spec.rb
+++ b/backend/spec/models/project_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Project, type: :model do
     it "loads new Transportation data if bbls have changed" do
       project = create(:project)
 
-      expect(project.transportation_analysis).to receive(:load_data!)
+      expect(project.transportation_analysis).to receive(:compute_for_updated_bbls!)
 
       project.bbls = [3019790030]
       project.save
@@ -56,7 +56,7 @@ RSpec.describe Project, type: :model do
     it "does not load new Transportation data if bbls have not changed" do
       project = create(:project)
 
-      expect(project.transportation_analysis).not_to receive(:load_data!)
+      expect(project.transportation_analysis).not_to receive(:compute_for_updated_bbls!)
 
       project.bbls = attributes_for(:project)[:bbls]
       project.save

--- a/backend/spec/models/transportation_analysis_spec.rb
+++ b/backend/spec/models/transportation_analysis_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TransportationAnalysis, type: :model do
 
     @censusTractMock = class_double('CensusTract')
     allow(@censusTractMock).to receive(:for_geom).and_return(['foo'])
+    allow(@censusTractMock).to receive(:touches_geoids).and_return(['foo'])
     allow(@censusTractMock).to receive(:st_union_geoids_centroid).and_return(generate(:point))
 
     stub_const("#{Db}::TrafficZone", @trafficZoneMock)
@@ -26,13 +27,18 @@ RSpec.describe TransportationAnalysis, type: :model do
       expect(analysis.traffic_zone).to be(4)
     end
 
-    it "sets study selection based on project study area" do
+    it "sets required study selection based on project study area" do
       allow(@censusTractMock).to receive(:for_geom).and_return(['bar'])
       expect(analysis.required_jtw_study_selection).to eq(['bar'])
     end
 
     it "sets the geographic centroid of the study area" do
       expect(analysis.jtw_study_area_centroid).to be_present
+    end
+
+    it "sets the default study selection based on required study selection" do
+      allow(@censusTractMock).to receive(:touches_geoids).and_return(['baz'])
+      expect(analysis.jtw_study_selection).to eq(['baz'])
     end
   end
 

--- a/frontend/app/components/transportation/study-area-map.js
+++ b/frontend/app/components/transportation/study-area-map.js
@@ -24,19 +24,9 @@ export default class TransportationProjectMapComponent extends Component {
     }
   }
 
-    /**
-   * The composite array of all highlighted features, including:
-   * - currently hovered feature
-   * - user-selected study selection features
-   * - required study selection features
-   * which is passed to the highlight layer's FeatureFilterer
-   */
-  @computed('hoveredFeatureId', 'analysis.{jtwStudySelection.[],requiredJtwStudySelection.[]}')
-  get highlightedFeatureIds() {
-    const { hoveredFeatureId } = this;
+  @computed('analysis.jtwStudySelection.[]')
+  get jtwStudySelectionComputed() {
     const selectedFeatures = this.get('analysis.jtwStudySelection') || [];
-    const requiredSelectedFeatures = this.get('analysis.requiredJtwStudySelection') || [];
-
-    return [hoveredFeatureId, ...selectedFeatures, ...requiredSelectedFeatures];
+    return [...selectedFeatures];
   }
 }

--- a/frontend/app/components/transportation/study-area-map/study-selection-toggler.js
+++ b/frontend/app/components/transportation/study-area-map/study-selection-toggler.js
@@ -34,13 +34,14 @@ export default class TransportationStudyAreaMapStudySelectionTogglerComponent ex
   async toggleCensusTract(selectedCensusTractFeatureArray) {
     const analysis = await this.analysis;
     const existingStudySelection = analysis.get('jtwStudySelection');
+    const requiredStudySelection = analysis.get('requiredJtwStudySelection');
     // check that selectedCensusTractFeature array exists and has an item
     if (selectedCensusTractFeatureArray && selectedCensusTractFeatureArray.length) {
       let { geoid } = selectedCensusTractFeatureArray[0].properties || {};
-      // check that the feature has a geoid property
-      if(geoid) {
+      // check that the feature has a geoid property and is not part of the required selection
+      if(geoid && !requiredStudySelection.includes(geoid)) {
         if(existingStudySelection.includes(geoid)){
-          existingStudySelection.popObject(geoid);
+          existingStudySelection.removeObject(geoid);
         } else {
           existingStudySelection.pushObject(geoid);
         }

--- a/frontend/app/models/transportation-analysis.js
+++ b/frontend/app/models/transportation-analysis.js
@@ -4,7 +4,7 @@ import { attr, belongsTo } from '@ember-decorators/data';
 import { computed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 
-export default class TransportationAnalysisModel extends Model {    
+export default class TransportationAnalysisModel extends Model {
   @belongsTo project;
 
   // Attributes
@@ -13,6 +13,8 @@ export default class TransportationAnalysisModel extends Model {
   @attr({defaultValue: () => []}) requiredJtwStudySelection;
   // the geoids of additional user-defined study selection
   @attr({defaultValue: () => []}) jtwStudySelection;
+  // the computed centroid of the study selection
+  @attr({defaultValue: () => []}) jtwStudyAreaCentroid;
 
   // Detailed Analysis trigger
   @computed(

--- a/frontend/app/routes/project/show/edit.js
+++ b/frontend/app/routes/project/show/edit.js
@@ -4,7 +4,7 @@ import { debug } from '@ember/debug';
 
 export default Route.extend({
   controllerName: 'edit-project',
-  
+
   'public-schools': service(),
   'project-orchestrator': service(),
 
@@ -15,14 +15,16 @@ export default Route.extend({
   },
 
   actions: {
-    save: async function(changeset) {                  
+    save: async function(changeset) {
       await changeset.validate();
 
       if (!changeset.isValid) return;
-      
+
       try {
         const project = await changeset.save();
-
+        // ensure changes to analyses triggered by project updates are reloaded
+        await project.transportationAnalysis.reload();
+        await project.publicSchoolsAnalysis.reload();
         this.get('public-schools').set('analysis', await project.publicSchoolsAnalysis);
         this.get('public-schools.fullReload').perform();
 
@@ -34,6 +36,6 @@ export default Route.extend({
 
     rollback: function(changeset) {
       return changeset.rollback();
-    } 
+    }
   }
 });

--- a/frontend/app/services/public-schools.js
+++ b/frontend/app/services/public-schools.js
@@ -14,7 +14,7 @@ export default Service.extend({
 
     this.set('analysis.multipliers', multipliers);
     this.set('analysis.dataTables', dataTables);
-    
+
     yield this.fullReload.perform();
   }),
 

--- a/frontend/app/templates/components/transportation/study-area-map.hbs
+++ b/frontend/app/templates/components/transportation/study-area-map.hbs
@@ -2,8 +2,8 @@
   @name="study-area-map"
   @initOptions={{hash
     style="https://layers-api.planninglabs.nyc/v1/base/style.json"
-    zoom=9.2
-    center=(array -74 40.7071266)
+    zoom=12
+    center=analysis.jtwStudyAreaCentroid
   }} as |map|
 >
   <Mapbox::CartoVectorSource @map={{map}} as |carto-source|>
@@ -48,7 +48,45 @@
     </carto-source.layer>
 
     <carto-source.layer
-      @id="tracts-highlight"
+      @id="tracts-hover"
+      @sql="select * from nyc_census_tracts_2010"
+      @layer={{hash
+        type="fill"
+        paint=(hash
+          fill-opacity=0.5
+          fill-color="#d6ff00"
+        )
+      }} as |layer|
+    >
+      <Mapbox::FeatureFilterer
+        @map={{map}}
+        @layerId={{layer.layerId}}
+        @filterById="geoid"
+        @featureIds={{array this.hoveredFeatureId}}
+      />
+    </carto-source.layer>
+
+    <carto-source.layer
+      @id="tracts-required"
+      @sql="select * from nyc_census_tracts_2010"
+      @layer={{hash
+        type="fill"
+        paint=(hash
+          fill-opacity=0.5
+          fill-color="#002d00"
+        )
+      }} as |layer|
+    >
+      <Mapbox::FeatureFilterer
+        @map={{map}}
+        @layerId={{layer.layerId}}
+        @filterById="geoid"
+        @featureIds={{this.analysis.requiredJtwStudySelection}}
+      />
+    </carto-source.layer>
+
+    <carto-source.layer
+      @id="tracts-selected"
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
@@ -62,9 +100,10 @@
         @map={{map}}
         @layerId={{layer.layerId}}
         @filterById="geoid"
-        @featureIds={{this.highlightedFeatureIds}}
+        @featureIds={{this.jtwStudySelectionComputed}}
       />
     </carto-source.layer>
+
 
     <carto-source.layer
       @id="subway"

--- a/frontend/mirage/factories/transportation-analysis.js
+++ b/frontend/mirage/factories/transportation-analysis.js
@@ -2,8 +2,14 @@ import { Factory, association } from 'ember-cli-mirage';
 
 export default Factory.extend({
   trafficZone: 2,
-  jtwStudySelection: () => [
+  requiredJtwStudySelection: () => [
       "36061020300"
+  ],
+  jtwStudySelection: () => [
+    '36061020500', '36061021100', '36061019701', '36061020701', '36061020101', '36061019900'
+  ],
+  jtwStudyAreaCentroid: () => [
+    -73.964251, 40.8080809
   ],
   project: association({
     totalUnits: 1000,

--- a/frontend/tests/integration/components/transportation/study-area-map-test.js
+++ b/frontend/tests/integration/components/transportation/study-area-map-test.js
@@ -70,7 +70,9 @@ module('Integration | Component | transportation/study-area-map', function(hooks
 
     assert.ok(this.layers.includes('tracts-line'));
     assert.ok(this.layers.includes('tracts-fill'));
-    assert.ok(this.layers.includes('tracts-highlight'));
+    assert.ok(this.layers.includes('tracts-hover'));
+    assert.ok(this.layers.includes('tracts-required'));
+    assert.ok(this.layers.includes('tracts-selected'));
     assert.ok(this.layers.includes('subway'));
     assert.ok(this.layers.includes('bus'));
   });

--- a/frontend/tests/integration/components/transportation/study-area-map/study-selection-toggler-test.js
+++ b/frontend/tests/integration/components/transportation/study-area-map/study-selection-toggler-test.js
@@ -37,7 +37,7 @@ module('Integration | Component | transportation/study-area-map/study-selection-
       .findRecord('project', project.id, { include: 'transportation-analysis'});
 
     const geoid = 'geoid';
-    this.model.set('transportationAnalysis.jtwStudySelection', [geoid]);
+    this.model.set('transportationAnalysis.jtwStudySelection', [geoid, '1', '2']);
 
      // When a feature with given geoid is selected
     await render(hbs`
@@ -48,7 +48,7 @@ module('Integration | Component | transportation/study-area-map/study-selection-
 
     // Then the geoid should be removed from the transportationAnalysis study selection
     const updatedStudySelection = await this.get('model.transportationAnalysis.jtwStudySelection');
-    assert.equal(updatedStudySelection.length, 0)
+    assert.equal(updatedStudySelection.length, 2)
     assert.notOk(updatedStudySelection.includes(geoid));
   });
 

--- a/frontend/tests/unit/components/transportation/study-area-map-test.js
+++ b/frontend/tests/unit/components/transportation/study-area-map-test.js
@@ -6,28 +6,19 @@ module('Unit | Component | transportation/study-area-map', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
-  test('it computes correct highlightedFeatureIds', async function(assert) {
+  test('it computes correct jtwStudySelectionComputed', async function(assert) {
     // if project exists with transportationAnalysis with the given study selection id arrays
     const jtwStudySelection = ['selectedGeoid1', 'selectedGeoid2'];
-    const requiredJtwStudySelection = ['requiredGeoid1', 'requiredGeoid2'];
     const project = server.create('project');
     const model = await this.owner.lookup('service:store')
       .findRecord('project', project.id, { include: 'transportation-analysis'});
     model.set('transportationAnalysis.jtwStudySelection', jtwStudySelection);
-    model.set('transportationAnalysis.requiredJtwStudySelection', requiredJtwStudySelection);
 
-    // when the component is rendered with that project, and has the given hovered feature id
+    // when the component is rendered with that project
     let component = this.owner.factoryFor('component:transportation/study-area-map').create({analysis: model.transportationAnalysis});
-    const hoveredGeoid = 'hoveredGeoid';
-    component.setFirstHoveredFeatureId([{ properties: { geoid: hoveredGeoid } }])
 
-    // then the component's highlightedFeatureIds property should include:
-    const highlightedFeatureIds = component.get('highlightedFeatureIds');
-    // all of the requiredJtwStudySelection ids
-    assert.ok(requiredJtwStudySelection.every(id => highlightedFeatureIds.includes(id)));
-    // all of the jtwStudySelection ids
+    // then the component's jtwStudySelectionComputed property should include the study selection ids
+    const highlightedFeatureIds = component.get('jtwStudySelectionComputed');
     assert.ok(jtwStudySelection.every(id => highlightedFeatureIds.includes(id)));
-    // the hovered id
-    assert.ok(highlightedFeatureIds.includes(hoveredGeoid));
   });
 });


### PR DESCRIPTION
This PR adds adjacent census tracts to requiredJtwStudySelection as jtwStudySelection on project creation, or when project bbls are updated. 
Additionally:
- separate feature fill layers to clarify required, selected and hovered
geoms
- fixup census tract toggle to correctly remove clicked feature from
selection + test
- center map on study area centroid and increase zoom

See `models/transportation_analysis.rb` for the meat of this change