### PR TITLE
399 new trip generation route (step)

### DIFF
--- a/frontend/app/components/transportation/study-area-map.js
+++ b/frontend/app/components/transportation/study-area-map.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { computed, action } from '@ember-decorators/object';
 
-export default class TransportationProjectMapComponent extends Component {
+export default class TransportationStudyAreaMapComponent extends Component {
   /**
    * The project model
    */

--- a/frontend/app/components/transportation/trip-generation-map.js
+++ b/frontend/app/components/transportation/trip-generation-map.js
@@ -1,0 +1,42 @@
+import Component from '@ember/component';
+import { computed, action } from '@ember-decorators/object';
+
+export default class TransportationTripGenerationMapComponent extends Component {
+  /**
+   * The transportation-analysis Model, passed down from the project/show/transportation-analysis controller
+   */
+  analysis = {};
+
+  /**
+   * The identifier (geoid) of the currenlty hovered feature in the map
+   */
+  hoveredFeatureId = null;
+
+  /**
+   * Sets hoveredFeatureId to geoid of the first feature in features array argument
+   */
+  @action
+  setFirstHoveredFeatureId(features){
+    if(features && features.length && features[0]){
+      this.set('hoveredFeatureId', features[0].properties.geoid);
+    } else {
+      this.set('hoveredFeatureId', null);
+    }
+  }
+
+    /**
+   * The composite array of all highlighted features, including:
+   * - currently hovered feature
+   * - user-selected study selection features
+   * - required study selection features
+   * which is passed to the highlight layer's FeatureFilterer
+   */
+  @computed('hoveredFeatureId', 'analysis.{jtwStudySelection.[],requiredJtwStudySelection.[]}')
+  get highlightedFeatureIds() {
+    const { hoveredFeatureId } = this;
+    const selectedFeatures = this.get('analysis.jtwStudySelection') || [];
+    const requiredSelectedFeatures = this.get('analysis.requiredJtwStudySelection') || [];
+
+    return [hoveredFeatureId, ...selectedFeatures, ...requiredSelectedFeatures];
+  }
+}

--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -69,6 +69,7 @@ Router.map(function() {
         this.route('existing-conditions', function() {
           this.route('study-area');
           this.route('journey-to-work');
+          this.route('trip-generation');
         });
       });
 

--- a/frontend/app/routes/project/show/transportation/existing-conditions/trip-generation.js
+++ b/frontend/app/routes/project/show/transportation/existing-conditions/trip-generation.js
@@ -1,0 +1,18 @@
+import Route from '@ember/routing/route';
+
+export default class ProjectShowTransportationExistingConditionsTripGenerationRoute extends Route {
+  controllerName = 'project';
+
+  renderTemplate() {
+    this.render('project/show/transportation/existing-conditions/trip-generation/map', {
+      into: 'project/show/transportation/existing-conditions',
+      outlet: 'map',
+      controller: this.controllerName
+    })
+    this.render('project/show/transportation/existing-conditions/trip-generation/table', {
+      into: 'project/show/transportation/existing-conditions',
+      outlet: 'table',
+      controller: this.controllerName
+    })
+  }
+}

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -80,7 +80,7 @@ footer {
   vertical-align: inherit; 
 }
 
-#study-area-map {
+#study-area-map, #trip-generation-map, #jtw-map {
   height: 550px;
 }
 

--- a/frontend/app/templates/components/transportation/existing-conditions/existing-conditions-steps.hbs
+++ b/frontend/app/templates/components/transportation/existing-conditions/existing-conditions-steps.hbs
@@ -7,6 +7,13 @@
     Study Area
   {{/link-to}}
   {{#link-to
+    "project.show.transportation.existing-conditions.trip-generation"
+    project.id
+    class="item"
+  }}
+    Trip Generation
+  {{/link-to}}
+  {{#link-to
     "project.show.transportation.existing-conditions.journey-to-work"
     project.id
     class="item"

--- a/frontend/app/templates/components/transportation/jtw-map.hbs
+++ b/frontend/app/templates/components/transportation/jtw-map.hbs
@@ -1,5 +1,5 @@
 <Mapbox::BasicMap
-  @name="study-area-map"
+  @name="jtw-map"
   @initOptions={{hash
     style="mapbox://styles/mapbox/light-v9"
     zoom=13

--- a/frontend/app/templates/components/transportation/trip-generation-map.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-map.hbs
@@ -1,0 +1,85 @@
+<Mapbox::BasicMap
+  @name="trip-generation-map"
+  @initOptions={{hash
+    style="https://layers-api.planninglabs.nyc/v1/base/style.json"
+    zoom=9.2
+    center=(array -74 40.7071266)
+  }} as |map|
+>
+  wel pinside msp
+  <Mapbox::CartoVectorSource @map={{map}} as |carto-source|>
+    <carto-source.layer
+      @id="tracts-line"
+      @sql="select * from nyc_census_tracts_2010"
+      @layer={{hash
+        type="line"
+        paint=(hash line-color="green")
+      }}
+    />
+    <carto-source.layer
+      @id="tracts-fill"
+      @sql="select * from nyc_census_tracts_2010"
+      @layer={{hash
+        type="fill"
+        paint=(hash fill-opacity=0)
+      }} as |layer|
+    >
+      <Mapbox::FeatureHoverer
+        @map={{map}}
+        @layerId={{layer.layerId}}
+        @onFeatures={{this.setFirstHoveredFeatureId}}
+        as |hoverer|
+      > 
+        {{#if (and hoverer.point hoverer.features)}}
+          <HoverCard @point={{hoverer.point}}>
+            <Transportation::StudyAreaMap::CensusTractPopup
+              @feature={{hoverer.features.firstObject}}
+              data-test-popup='census-tract'
+            />
+          </HoverCard>
+        {{/if}}
+      </Mapbox::FeatureHoverer>
+    </carto-source.layer>
+
+    <carto-source.layer
+      @id="tracts-highlight"
+      @sql="select * from nyc_census_tracts_2010"
+      @layer={{hash
+        type="fill"
+        paint=(hash
+          fill-opacity=0.5
+          fill-color="green"
+        )
+      }} as |layer|
+    >
+      <Mapbox::FeatureFilterer
+        @map={{map}}
+        @layerId={{layer.layerId}}
+        @filterById="geoid"
+        @featureIds={{this.highlightedFeatureIds}}
+      />
+    </carto-source.layer>
+
+    <carto-source.layer
+      @id="subway"
+      @sql="select * from mta_subway_routes_v0"
+      @layer={{hash
+        type="line"
+        paint=(hash line-color="red")
+      }}
+     />
+
+    <carto-source.layer
+      @id="bus"
+      @sql="select * from mta_bus_stops_v0"
+      @layer={{hash
+        type="circle"
+        paint=(hash
+          circle-color="pink"
+          circle-radius=1
+        )
+      }}
+     />
+
+  </Mapbox::CartoVectorSource>
+</Mapbox::BasicMap>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/map.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/map.hbs
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="sixteen wide column">
+    <Transportation::TripGenerationMap
+      @analysis={{this.project.transportationAnalysis}}
+    />
+  </div>
+</div>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/table.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/table.hbs
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="sixteen wide column">
+    Trip Gen Table
+  </div>
+</div>

--- a/frontend/tests/integration/components/transportation/trip-generation-map-test.js
+++ b/frontend/tests/integration/components/transportation/trip-generation-map-test.js
@@ -1,0 +1,76 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import Component from '@ember/component';
+import { registerEventHandler}  from '../../../helpers/mapbox/mapbox-stub-helpers';
+
+const DEFAULT_MAPBOX_GL_INSTANCE = {
+  addSource: () => {},
+  addLayer: () => {},
+  removeLayer: () => {},
+  removeSource: () => {},
+  getStyle: () => ({}),
+  queryRenderedFeatures: () => [],
+  on: () => {},
+  off: () => {},
+};
+
+module('Integration | Component | transportation/trip-generation-map', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    this.events = {};
+    this.layers = [];
+    this.filters = {}
+    this.map = {
+      ...DEFAULT_MAPBOX_GL_INSTANCE,
+      addLayer: ({ id }) => {
+        this.layers.push(id);
+      },
+      queryRenderedFeatures: () => {
+        return [{
+          type: 'Feature',
+          properties: {
+            geoid: 'test',
+          },
+        }]
+      },
+      setFilter: (layerId, filter) => {
+        this.filters[layerId] = filter;
+      },
+      // On render, component templates like `current-map-position.js`
+      // will associate action handlers to fired mouse events and 
+      // mantain a list of these associations. 
+      // We simulate this association list locally (with the `events` object)
+      // so that we can make ad hoc calls to action handlers. See comment below
+      // in `it hovers, displays information`.
+      on: (event, action) => {
+        registerEventHandler(this.events, event, action);
+      }
+    };
+
+    const that = this;
+    class BasicMapStub extends Component {
+      map = that.map;
+    }
+
+    this.owner.register('component:mapbox/basic-map', BasicMapStub);
+    this.owner.register('template:components/mapbox/basic-map', hbs`
+      {{yield (hash instance=this.map)}}
+    `);
+  });
+
+  test('it has highlighted tracts, buses, and subways in map', async function(assert) {
+
+    await render(hbs`{{transportation/trip-generation-map}}`);
+
+    assert.ok(this.layers.includes('tracts-line'));
+    assert.ok(this.layers.includes('tracts-fill'));
+    assert.ok(this.layers.includes('tracts-highlight'));
+    assert.ok(this.layers.includes('subway'));
+    assert.ok(this.layers.includes('bus'));
+  });
+});

--- a/frontend/tests/unit/controllers/project/project-test.js
+++ b/frontend/tests/unit/controllers/project/project-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | project', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:project');
+    assert.ok(controller);
+  });
+
+});

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/study-area-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/study-area-test.js
@@ -13,5 +13,4 @@ module('Unit | Route | project/show/transportation/existing-conditions/study-are
     let route = this.owner.lookup('route:project/show/transportation/existing-conditions/study-area');
     assert.equal(route.controllerName, 'project');
   });
-
 });

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/trip-generation-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/trip-generation-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | project/show/transportation/existing-conditions/trip-generation', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/trip-generation');
+    assert.ok(route);
+  });
+
+  test('it is bound to the project controller', function(assert) {
+    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/trip-generation');
+    assert.equal(route.controllerName, 'project');
+  });
+});


### PR DESCRIPTION
## What
New route for the "trip generation" step under `.../transportation/existing-conditions/` route. 
Also does scaffolding for the trip generation step's static non-interactive map.

## Entrypoint
`templates/components/transportation/existing-conditions/existing-conditions-steps.hbs` holds the stepper UI, which received a new "trip generation" step button linking to the new `trip-generation` route. 

## Thoughts
There's beginning to be a build up of duplicate map code across the different step-specific maps. Seems necessary at this point since each map will have different functionality/purpose. 

But they often share the same styles for their layers. If "tracts-line" styles changed for example, it needs to be applied across all three maps.

## Todo
There will be a follow-up PR to rename `study-area` and `jtw` components to new step names.