### PR TITLE
371 standardize styles

### DIFF
--- a/frontend/app/components/transportation/study-area-map.js
+++ b/frontend/app/components/transportation/study-area-map.js
@@ -3,13 +3,12 @@ import { computed, action } from '@ember-decorators/object';
 
 export default class TransportationProjectMapComponent extends Component {
   /**
-   * The transportation-analysis Model, passed down from the project/show/transportation-analysis controller
+   * The project model
    */
-  analysis = {};
-
+  project = {};
   /**
    * The identifier (geoid) of the currenlty hovered feature in the map
-   */
+  */
   hoveredFeatureId = null;
 
   /**
@@ -24,9 +23,44 @@ export default class TransportationProjectMapComponent extends Component {
     }
   }
 
-  @computed('analysis.jtwStudySelection.[]')
+  /**
+   * Computed property that enables feature filterer to receive array mutations in didReceiveAttrs()
+   */
+  @computed('project.transportationAnalysis.jtwStudySelection.[]')
   get jtwStudySelectionComputed() {
-    const selectedFeatures = this.get('analysis.jtwStudySelection') || [];
+    const selectedFeatures = this.get('project.transportationAnalysis.jtwStudySelection') || [];
     return [...selectedFeatures];
+  }
+
+  /**
+   * Computed property that enables feature filterer to filter on required and normal study selection
+   */
+  @computed('project.transportationAnalysis.{jtwStudySelection.[],requiredJtwStudySelection.[]}')
+  get allJtwStudySelectionComputed() {
+    const selectedFeatures = this.get('project.transportationAnalysis.jtwStudySelection') || [];
+    const requiredFeatures = this.get('project.transportationAnalysis.requiredJtwStudySelection') || [];
+    return [...selectedFeatures, ...requiredFeatures];
+  }
+
+  /**
+   * Action to pass to the MapboxGL instance created by Mapbox::Basic map in this component's template
+   */
+  @action
+  mapLoaded(map) {
+    map.on('data', this.onMapStyleLoaded);
+  }
+
+  /**
+   * Helper function to ensure 'bbls' layer is the top-most layer. MapboxGL styleIsLoaded() check,
+   * and 'style.load' events do not reliably indicate a fully loaded style object.
+   * To display 'bbls' as the top-most layer, must move it with moveLayer()
+   */
+  onMapStyleLoaded(e) {
+    const { target: map } = e;
+    const style = map.getStyle();
+    if (style.sources.bbls_geojson && style.sources.carto) {
+      map.moveLayer('bbls');
+      map.off('data', this.onMapStyleLoaded)
+    }
   }
 }

--- a/frontend/app/helpers/get-layer-style.js
+++ b/frontend/app/helpers/get-layer-style.js
@@ -1,0 +1,10 @@
+import { helper } from '@ember/component/helper';
+import { styles } from 'labs-ceqr/layer-styles'
+
+export function getLayerStyle(params/*, hash*/) {
+  const [layer, type] = params;
+  return styles[layer][type]; 
+   
+}
+
+export default helper(getLayerStyle);

--- a/frontend/app/layer-styles/index.js
+++ b/frontend/app/layer-styles/index.js
@@ -1,0 +1,9 @@
+import { subwayStyles } from 'labs-ceqr/layer-styles/subway';
+import { selectableFeatureStyles } from 'labs-ceqr/layer-styles/selectable-feature';
+import { projectBblStyles } from 'labs-ceqr/layer-styles/project-bbl';
+
+export const styles  = {
+  ...subwayStyles,
+  ...selectableFeatureStyles,
+  ...projectBblStyles,
+};

--- a/frontend/app/layer-styles/project-bbl.js
+++ b/frontend/app/layer-styles/project-bbl.js
@@ -1,0 +1,9 @@
+export const projectBblStyles = {
+  'bbls': {
+    paint: {
+      'line-color': '#d7191c',
+      'line-width': 4,
+      'line-blur': 1,    
+    },
+  },
+};

--- a/frontend/app/layer-styles/selectable-feature.js
+++ b/frontend/app/layer-styles/selectable-feature.js
@@ -1,0 +1,63 @@
+export const selectableFeatureStyles = {
+  'selectable-feature-content': {
+    paint: {
+      'fill-opacity': 0,
+    },
+  },
+  'selectable-feature-line': {
+    paint: {
+      'line-color': '#444',
+      'line-opacity': 0.5,
+      'line-width': {
+        stops: [
+          [11, 1],
+          [16, 3],
+        ],
+      },
+    },
+    'layout': {
+      'line-cap': 'round',
+      'line-join': 'round',
+    },
+  },
+  'selectable-feature-hover': {
+    paint: {
+      'line-color': '#585858',
+      'line-opacity': 0.3,
+      'line-width': {
+        stops: [
+          [8, 4],
+          [11, 7],
+        ],
+      },
+    },
+  },
+  'selectable-feature-selected-fill-bold': {
+    paint: {
+      'fill-color': 'rgba(59, 101, 216, 1)',
+      'fill-opacity': 0.8,
+    },
+  },
+  'selectable-feature-selected-fill-light': {
+    paint: {
+      'fill-color': 'rgba(59, 101, 216, 1)',
+      'fill-opacity': 0.4,
+    },
+  },
+  'selectable-feature-selected-line': {
+    paint: {
+      'line-color': 'black',
+      'line-opacity': 0.5,
+      'line-width': {
+        stops: [
+          [11, 1],
+          [16, 3],
+        ],
+      },
+    },
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round'
+    },
+  },
+};

--- a/frontend/app/layer-styles/subway.js
+++ b/frontend/app/layer-styles/subway.js
@@ -1,0 +1,53 @@
+export const subwayStyles = {
+  'subway-routes': {
+    paint: {
+      'line-color': {
+        property: 'rt_symbol',
+        type: 'categorical',
+        stops: [
+          ['4', 'rgba(0, 147, 60, 1)'],
+          ['N', 'rgba(252, 204, 10, 1)'],
+          ['L', 'rgba(167, 169, 172, 1)'],
+          ['J', 'rgba(153, 102, 51, 1)'],
+          ['G', 'rgba(108, 190, 69, 1)'],
+          ['B', 'rgba(255, 99, 25, 1)'],
+          ['A', 'rgba(0, 57, 166, 1)'],
+          ['SI', 'rgba(0, 57, 166, 1)' ],
+          ['7', 'rgba(185, 51, 173, 1)'],
+          ['1', 'rgba(238, 53, 46, 1)'],
+        ],
+      },
+      'line-width': {
+        stops: [
+          [10, 1],
+          [15, 4],
+        ],
+      },
+    },
+  },
+  'subway-stops': {
+    paint: {
+      'circle-color': 'rgba(255, 255, 255, 1)',
+      'circle-opacity': {
+        stops: [
+          [11, 0],
+          [12, 1],
+        ],
+      },
+      'circle-stroke-opacity': {
+        stops: [
+          [11, 0],
+          [12, 1],
+        ],
+      },
+      'circle-radius': {
+        stops: [
+          [10, 2],
+          [14, 5],
+        ],
+      },
+      'circle-stroke-width': 1,
+      'circle-pitch-scale': 'map',
+    },
+  },
+};

--- a/frontend/app/templates/components/mapbox/basic-map.hbs
+++ b/frontend/app/templates/components/mapbox/basic-map.hbs
@@ -1,5 +1,6 @@
 <MapboxGl
   @id={{this.name}}
+  @mapLoaded={{this.mapLoaded}}
   @initOptions={{this.initOptions}} as |map|
 >
   {{yield (hash instance=map.instance)}}

--- a/frontend/app/templates/components/mapbox/carto-vector-source.hbs
+++ b/frontend/app/templates/components/mapbox/carto-vector-source.hbs
@@ -7,7 +7,7 @@
     {{! Add the source }}
     <MapboxGlSource
       @map={{map.instance}}
-      @sourceId={{this.elementId}}
+      @sourceId={{if this.sourceId this.sourceId this.elementId}}
       @options={{this.mapboxSourceOptions}}
      />
 
@@ -20,7 +20,7 @@
         unregisterWithParent=(action registry.unregisterLayer)
         map=map
         tiles=this.mapboxSourceOptions.tiles
-        _parentElementId=this.elementId
+        _parentElementId=(if this.sourceId this.sourceId this.elementId)
       )
     )
   }}

--- a/frontend/app/templates/components/public-schools/project-map.hbs
+++ b/frontend/app/templates/components/public-schools/project-map.hbs
@@ -234,7 +234,6 @@
             )
           }}
          />
-
       </map.source>
     {{/if}}
   {{/if}}
@@ -245,7 +244,7 @@
       @layer={{hash
         id="bbls"
         type="line"
-        paint=(hash line-color="#d7191c" line-width=4 line-blur=1)
+        paint=(get-layer-style 'bbls' 'paint')
       }}
      />
 

--- a/frontend/app/templates/components/transportation/study-area-map.hbs
+++ b/frontend/app/templates/components/transportation/study-area-map.hbs
@@ -1,26 +1,51 @@
 <Mapbox::BasicMap
   @name="study-area-map"
+  @mapLoaded={{action mapLoaded}}
   @initOptions={{hash
     style="https://layers-api.planninglabs.nyc/v1/base/style.json"
     zoom=12
-    center=analysis.jtwStudyAreaCentroid
+    center=this.project.transportationAnalysis.jtwStudyAreaCentroid
   }} as |map|
 >
-  <Mapbox::CartoVectorSource @map={{map}} as |carto-source|>
-    <carto-source.layer
-      @id="tracts-line"
-      @sql="select * from nyc_census_tracts_2010"
+  <MapboxGlSource
+    @sourceId='bbls_geojson'
+    @map={{map.instance}}
+    @options={{hash type="geojson" data=project.bblsGeojson}} as |source|
+  >
+    <source.layer
       @layer={{hash
+        id="bbls"
         type="line"
-        paint=(hash line-color="green")
+        paint=(get-layer-style 'bbls' 'paint')
       }}
     />
+  </MapboxGlSource>
+
+  <Mapbox::CartoVectorSource @sourceId="carto" @map={{map}} as |carto-source|>
+
     <carto-source.layer
-      @id="tracts-fill"
+      @id="subway-routes"
+      @sql="select * from mta_subway_routes_v0"
+      @layer={{hash
+        type="line"
+        paint=(get-layer-style 'subway-routes' 'paint')
+      }}
+     />
+
+    <carto-source.layer
+      @id="subway-stops"
+      @sql="select * from mta_subway_stops_v0"
+      @layer={{hash
+        type="circle"
+        paint=(get-layer-style 'subway-stops' 'paint')
+      }}
+     />
+    <carto-source.layer
+      @id="tracts"
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(hash fill-opacity=0)
+        paint=(get-layer-style 'selectable-feature-content' 'paint')
       }} as |layer|
     >
       <Mapbox::FeatureHoverer
@@ -28,7 +53,7 @@
         @layerId={{layer.layerId}}
         @onFeatures={{this.setFirstHoveredFeatureId}}
         as |hoverer|
-      > 
+      >
         {{#if (and hoverer.point hoverer.features)}}
           <HoverCard @point={{hoverer.point}}>
             <Transportation::StudyAreaMap::CensusTractPopup
@@ -38,24 +63,32 @@
           </HoverCard>
         {{/if}}
       </Mapbox::FeatureHoverer>
+
       <Mapbox::FeatureSelector
         @map={{map}}
         @layerId={{layer.layerId}} as |selectedFeatures| >
         <Transportation::StudyAreaMap::StudySelectionToggler
           @selectedFeatureArray={{selectedFeatures}}
-          @analysis={{analysis}} />
+          @analysis={{this.project.transportationAnalysis}} />
       </Mapbox::FeatureSelector>
     </carto-source.layer>
+
+    <carto-source.layer
+      @id="tracts-line"
+      @sql="select * from nyc_census_tracts_2010"
+      @layer={{hash
+        type="line"
+        paint=(get-layer-style 'selectable-feature-line' 'paint')
+        layout=(get-layer-style 'selectable-feature-line' 'layout')
+      }}
+    />
 
     <carto-source.layer
       @id="tracts-hover"
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
-        type="fill"
-        paint=(hash
-          fill-opacity=0.5
-          fill-color="#d6ff00"
-        )
+        type="line"
+        paint=(get-layer-style 'selectable-feature-hover' 'paint')
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -71,29 +104,23 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(hash
-          fill-opacity=0.5
-          fill-color="#002d00"
-        )
+        paint=(get-layer-style 'selectable-feature-selected-fill-bold' 'paint')
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
         @map={{map}}
         @layerId={{layer.layerId}}
         @filterById="geoid"
-        @featureIds={{this.analysis.requiredJtwStudySelection}}
+        @featureIds={{this.project.transportationAnalysis.requiredJtwStudySelection}}
       />
     </carto-source.layer>
 
     <carto-source.layer
-      @id="tracts-selected"
+      @id="tracts-user-selected"
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(hash
-          fill-opacity=0.5
-          fill-color="green"
-        )
+        paint=(get-layer-style 'selectable-feature-selected-fill-light' 'paint')
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -104,27 +131,23 @@
       />
     </carto-source.layer>
 
-
     <carto-source.layer
-      @id="subway"
-      @sql="select * from mta_subway_routes_v0"
+      @id="tracts-all-selected"
+      @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(hash line-color="red")
-      }}
-     />
+        paint=(get-layer-style 'selectable-feature-selected-line' 'paint')
+        layout=(get-layer-style 'selectable-feature-selected-line' 'layout')
+      }} as |layer|
+    >
+      <Mapbox::FeatureFilterer
+        @map={{map}}
+        @layerId={{layer.layerId}}
+        @filterById="geoid"
+        @featureIds={{this.allJtwStudySelectionComputed}}
+      />
+    </carto-source.layer>
 
-    <carto-source.layer
-      @id="bus"
-      @sql="select * from mta_bus_stops_v0"
-      @layer={{hash
-        type="circle"
-        paint=(hash
-          circle-color="pink"
-          circle-radius=1
-        )
-      }}
-     />
 
   </Mapbox::CartoVectorSource>
 </Mapbox::BasicMap>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/study-area/map.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/study-area/map.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::StudyAreaMap
-      @analysis={{this.project.transportationAnalysis}}
+      @project={{this.project}}
     />
   </div>
 </div>

--- a/frontend/mirage/factories/project.js
+++ b/frontend/mirage/factories/project.js
@@ -10,8 +10,29 @@ export default Factory.extend({
   viewOnly: false,
   name: faker.address.streetName,
   buildYear: 2018,
-  bbls: () => ['1001440001'],
+  bbls: () => ['1019730001'],
   bblsVersion: 'mappluto_18v2',
+  bblsGeojson: () => {
+    return {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Multipolygon',
+            coordinates: [
+              [-73.95944768975842, 40.80929214876363],
+              [-73.96112392735277, 40.80699583564126],
+              [-73.9635969491312, 40.808032096187006],
+              [-73.96192107071839, 40.81033240266901],
+              [-73.95944768975842, 40.80929214876363],
+            ],
+          },
+        },
+      ],
+    };
+  },
   borough: 'Manhattan',
   totalUnits: 1000,
   seniorUnits: 0,
@@ -42,7 +63,7 @@ export default Factory.extend({
 //         "type": "Feature",
 //         "geometry": {
 //           "type": "MultiPolygon",
-//           "coordinates": [ /* a bunch of coordinates here!!!!! */ ]
+//           "coordinates": [ [coordinates], [coordinates], [coordinates] ]
 //         },
 //         "properties": {}
 //       }

--- a/frontend/tests/integration/components/transportation/study-area-map-test.js
+++ b/frontend/tests/integration/components/transportation/study-area-map-test.js
@@ -64,17 +64,18 @@ module('Integration | Component | transportation/study-area-map', function(hooks
     `);
   });
 
-  test('it has tracts, buses, and subways in map', async function(assert) {
+  test('it has tracts and subways in map', async function(assert) {
 
     await render(hbs`{{transportation/study-area-map}}`);
 
+    assert.ok(this.layers.includes('subway-routes'));
+    assert.ok(this.layers.includes('subway-stops'));
+    assert.ok(this.layers.includes('tracts'));
     assert.ok(this.layers.includes('tracts-line'));
-    assert.ok(this.layers.includes('tracts-fill'));
     assert.ok(this.layers.includes('tracts-hover'));
     assert.ok(this.layers.includes('tracts-required'));
-    assert.ok(this.layers.includes('tracts-selected'));
-    assert.ok(this.layers.includes('subway'));
-    assert.ok(this.layers.includes('bus'));
+    assert.ok(this.layers.includes('tracts-user-selected'));
+    assert.ok(this.layers.includes('tracts-all-selected'));
   });
 
   test('it hovers, displays information', async function(assert) {
@@ -82,7 +83,7 @@ module('Integration | Component | transportation/study-area-map', function(hooks
 
     // To simulate an event, we go straight to simply calling
     // the event handler with whatever arguments (like clicked point)
-    // we want. 
+    // we want.
     simulateEvent(this.events, 'mousemove', { point: { x: 0, y: 0 }});
 
     await settled();
@@ -98,7 +99,7 @@ module('Integration | Component | transportation/study-area-map', function(hooks
 
     const geoid = renderedGeoId;
 
-    await render(hbs`{{transportation/study-area-map analysis=model.transportationAnalysis}}`);
+    await render(hbs`{{transportation/study-area-map project=model}}`);
     simulateEvent(this.events, 'click', {point: 'point'});
 
     await settled();

--- a/frontend/tests/integration/helpers/get-layer-style-test.js
+++ b/frontend/tests/integration/helpers/get-layer-style-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { styles } from 'labs-ceqr/layer-styles';
+
+module('Integration | Helper | get-layer-style', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns the correct style object', async function(assert) {
+    const layer = 'bbls';
+    this.set('layer', layer);
+    const type = 'paint';
+    this.set('type', type);
+
+    await render(hbs`{{get-layer-style layer type}}`);
+
+    assert.equal(this.element.textContent.trim(), styles[layer][type]);
+  });
+});

--- a/frontend/tests/unit/components/transportation/study-area-map-test.js
+++ b/frontend/tests/unit/components/transportation/study-area-map-test.js
@@ -15,7 +15,7 @@ module('Unit | Component | transportation/study-area-map', function(hooks) {
     model.set('transportationAnalysis.jtwStudySelection', jtwStudySelection);
 
     // when the component is rendered with that project
-    let component = this.owner.factoryFor('component:transportation/study-area-map').create({analysis: model.transportationAnalysis});
+    let component = this.owner.factoryFor('component:transportation/study-area-map').create({project: model});
 
     // then the component's jtwStudySelectionComputed property should include the study selection ids
     const highlightedFeatureIds = component.get('jtwStudySelectionComputed');


### PR DESCRIPTION
# what 
This PR extracts styles into javascript objects stored in `layer-styles` which are accessed in components with the `get-layer-styles` helpers. It adds some new layers (subway-stops, and more layers for displaying the selected/required/hovered features separately), and removes some layers as well (bus) 

Additionally:
- Updates the study-area-map to store the full project model, not just the transportation analysis model in order to access the bbls-geom for rendering on the map
- Updates the study-area-map to use jtw-centroid as the center of the map
- Creates a custom attribute type in `models/attributes` that formats the `jtwStudyAreaCentroid` point geometry as a LngLat-like array to avoid sending a much less useable `'POINT(X, Y)'` string to the frontend. 

# where
- frontend/app/helpers/get-layer-styles.js and frontend/app/layer-styles for the style extraction
- backend/app/models/attributes/lng_lat.rb for the custom attribute type

# tests
YES, but I'm not sure how to test the stuff i did to get the bbls layer to display on top, since we mock the mapboxGL instance in the study-area-map tests. Wondering if @allthesignals has any ideas?

# campsite 
no :( 

# note
this will be easier to look at once 372 branch is merged, but I didn't want to deal with resolving conflicts later. To see JUST this changeset, select a single commit and look at the diff there