### PR TITLE
418 Format Census Tract Popup table

### DIFF
--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -159,7 +159,27 @@ i.icons .school-under-construction.icon {
     font-size: 1.1em;
   }
 }
-
+.census-tract-popup {
+  font-size: 12px !important;
+  width: auto !important;
+  th {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  tbody {
+    td {
+      padding-top:    6px !important;
+      padding-bottom: 6px !important;
+      line-height: 12px !important;
+    }
+  }
+}
+.mapboxgl-map {
+  overflow: visible !important;
+}
+.mapboxgl-canvas {
+  outline: 0 !important;
+}
 .mapboxgl-popup {
   z-index: 2;
 }
@@ -178,10 +198,6 @@ i.icons .school-under-construction.icon {
 .traffic-zone-popup {
   margin: 5px 7px;
 }
-
-// .edit-cell input {
-//   width: 50px;
-// }
 
 .project.title {
   color: black;

--- a/frontend/app/templates/components/transportation/census-tracts-map/census-tract-popup.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-map/census-tract-popup.hbs
@@ -1,4 +1,4 @@
-<div class="ui card">
+<div class="census-tract-popup ui card">
   <div class="content">
     <div class="header">
       {{feature.properties.boroname}}

--- a/frontend/app/templates/components/transportation/census-tracts-map/census-tract-popup/modal-split-formatter.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-map/census-tract-popup/modal-split-formatter.hbs
@@ -1,4 +1,4 @@
-<table class='ui celled structured table'>
+<table class='ui celled structured unstackable table'>
   <thead>
     <tr>
       <th></th>
@@ -25,10 +25,10 @@
     {{#each this.displayVariables as |variable|}}
       <tr>
        <td data-test-mode={{variable}}>{{get (get acsData variable) 'mode'}}</td>
-       <td data-test-acs-value={{variable}}>{{get-split-value acsData variable true}}</td>
-       <td data-test-acs-percent={{variable}}>{{get-split-percent acsData (array variable)}}</td>
-       <td data-test-ctpp-value={{variable}}>{{get-split-value ctppData variable true}}</td>
-       <td data-test-ctpp-percent={{variable}}>{{get-split-percent ctppData (array variable)}}</td>
+       <td class="single line" data-test-acs-value={{variable}}>{{get-split-value acsData variable true}}</td>
+       <td class="single line" data-test-acs-percent={{variable}}>{{get-split-percent acsData (array variable)}}</td>
+       <td class="single line" data-test-ctpp-value={{variable}}>{{get-split-value ctppData variable true}}</td>
+       <td class="single line" data-test-ctpp-percent={{variable}}>{{get-split-percent ctppData (array variable)}}</td>
      </tr>
     {{/each}}
   </tbody>


### PR DESCRIPTION
Various adjustments to the Census Tracts Popup table:
 - Shrink text
 - Shrink `th` and `td` padding
 - Allow popup to flow outside map boundary
 - Auto popup width
 - Prevent Chrome blue outline on map focus
 - Prevent table stacking in mobile
 - Prevent wrapping for cell values and percents