### PR TITLE
433 connect ctpp data to backend

### DIFF
--- a/backend/app/controllers/api/v1/ctpp_estimates_controller.rb
+++ b/backend/app/controllers/api/v1/ctpp_estimates_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::CtppEstimatesController < ApiController
+
+end

--- a/backend/app/models/db/ctpp_estimate.rb
+++ b/backend/app/models/db/ctpp_estimate.rb
@@ -1,0 +1,12 @@
+class Db::CtppEstimate < DataRecord
+  # TODO: Allow switching the table through Sequel 
+  self.table_name = "ctpp_censustract_variables.2012_2016"
+
+  def self.st_union_geoids_centroid(geoids)
+    select('ST_CENTROID(ST_MULTI(ST_UNION(geom)))').where(geoid: geoids).first.st_centroid
+  end
+
+  def self.for_geom(geom)
+    select('DISTINCT geoid').where("ST_Intersects(ST_GeomFromText('#{geom.as_text}', #{geom.srid}), geom)").map &:geoid
+  end
+end

--- a/backend/app/resources/api/v1/ctpp_estimate_resource.rb
+++ b/backend/app/resources/api/v1/ctpp_estimate_resource.rb
@@ -1,0 +1,26 @@
+class Api::V1::CtppEstimateResource < JSONAPI::Resource
+  immutable
+  model_name 'Db::CtppEstimate'
+
+  attributes(
+    :geoid,
+    :variable,
+    :value,
+    :moe
+  )
+
+  def self.default_sort
+    [{field: 'geoid', direction: :desc}, {field: 'variable', direction: :desc}]
+  end
+
+  def id
+    "#{@model.geoid}_#{@model.variable}"
+  end
+
+  def version
+    Db::CtppEstimate.version
+  end
+
+  filter :variable
+  filter :geoid
+end

--- a/backend/app/resources/api/v1/transportation_analysis_resource.rb
+++ b/backend/app/resources/api/v1/transportation_analysis_resource.rb
@@ -3,7 +3,9 @@ class Api::V1::TransportationAnalysisResource < JSONAPI::Resource
     :traffic_zone,
     :jtw_study_selection,
     :required_jtw_study_selection,
-    :jtw_study_area_centroid
+    :jtw_study_area_centroid,
+    :in_out_dists,
+    :taxi_vehicle_occupancy
   )
 
   has_one :project

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       # Read-only data
       jsonapi_resources :bbls
       jsonapi_resources :acs_estimates
+      jsonapi_resources :ctpp_estimates
     end
   end
 end

--- a/backend/db/migrate/20190709193328_add_in_out_dists_to_transportation_analysis.rb
+++ b/backend/db/migrate/20190709193328_add_in_out_dists_to_transportation_analysis.rb
@@ -1,0 +1,24 @@
+class AddInOutDistsToTransportationAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    default_in_out_dist = {
+      am: {
+        in: 50,
+        out: 50
+      },
+      md: {
+        in: 50,
+        out: 50
+      },
+      pm: {
+        in: 50,
+        out: 50
+      },
+      saturday: {
+        in: 50,
+        out: 50
+      }
+    }
+
+    add_column :transportation_analyses, :in_out_dists, :jsonb, default: default_in_out_dist
+  end
+end

--- a/backend/db/migrate/20190711174257_add_taxi_vehicle_occupancy_to_transportation_analysis.rb
+++ b/backend/db/migrate/20190711174257_add_taxi_vehicle_occupancy_to_transportation_analysis.rb
@@ -1,0 +1,5 @@
+class AddTaxiVehicleOccupancyToTransportationAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transportation_analyses, :taxi_vehicle_occupancy, :float, null: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_14_020040) do
+ActiveRecord::Schema.define(version: 2019_07_11_174257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -96,6 +96,8 @@ ActiveRecord::Schema.define(version: 2019_06_14_020040) do
     t.geometry "jtw_study_area_centroid", limit: {:srid=>4326, :type=>"st_point"}, null: false
     t.string "required_jtw_study_selection", limit: 11, default: [], null: false, array: true
     t.string "jtw_study_selection", limit: 11, default: [], array: true
+    t.jsonb "in_out_dists", default: {"am"=>{"in"=>50, "out"=>50}, "md"=>{"in"=>50, "out"=>50}, "pm"=>{"in"=>50, "out"=>50}, "saturday"=>{"in"=>50, "out"=>50}}
+    t.float "taxi_vehicle_occupancy"
   end
 
   create_table "users", force: :cascade do |t|

--- a/frontend/app/components/transportation/census-tracts-map/census-tract-popup/modal-split-formatter.js
+++ b/frontend/app/components/transportation/census-tracts-map/census-tract-popup/modal-split-formatter.js
@@ -6,7 +6,7 @@ export const MODAL_SPLIT_POPUP_DISPLAY_VARIABLES = [
   'trans_public_subway',
   'trans_public_bus',
   'trans_walk_other',
-  'trans_commuter_total',
+  'trans_commuter_total'
 ];
 
 /**

--- a/frontend/app/components/transportation/census-tracts-table.js
+++ b/frontend/app/components/transportation/census-tracts-table.js
@@ -1,42 +1,34 @@
 import Component from '@ember/component';
-import { inject as service } from '@ember-decorators/service';
 import { computed } from '@ember-decorators/object';
-import { VARIABLE_MODE_LOOKUP, COMMUTER_VARIABLES } from '../../utils/modalSplit';
+import { getAggregateValue } from '../../helpers/get-aggregate-value';
 
 /**
  * CensusTractsTable component renders modal-split data for a project's study selection census tracts
- * in a table. The table updates as cenesus tracts are added to/removed from the study selection.
+ * in a table. The table updates as census tracts are added to/removed from the study selection.
  */
 export default class TransportationCensusTractsTableComponent extends Component {
-  @service store;
-  @service('readonly-ceqr-data-store') readonlyStore;
-
-  commuterModes = COMMUTER_VARIABLES;
-  modeLookup = VARIABLE_MODE_LOOKUP;
-
-  isRJTW = false;
 
   /**
-   * The transportation-analysis Model, passed down from the project/show/transportation-analysis controller
-   */
-  analysis = {};
+  * array of census tract IDs, each displayed as a column
+ * @param {string[]} 
+ */
+  selectedCensusTractIds = []
 
   /**
-   * Composite array containing geoids of all selected census tracts
-   */
-  @computed('analysis.{requiredJtwStudySelection.[],jtwStudySelection.[]}')
-  get selectedCensusTractIds() {
-    return [...this.get('analysis.jtwStudySelection'), ...this.get('analysis.requiredJtwStudySelection')];
+  * array of census tract modal splits, usually returned using readonlyStore.findByIds().
+  * Each modal split is displayed as a row.
+ * @param {modalSplit[]} 
+ */
+  selectedCensusTractData = []
+
+  // TODO: Figure out how to work around async selectedCensusTractData property.
+  // Then, move this into existing-conditions controller.
+  @computed('selectedCensusTractData.[]')
+  get vehicleOccupancyAvg() {
+    if(this.selectedCensusTractData){
+      return getAggregateValue([this.selectedCensusTractData, ["vehicle_occupancy"]]) / this.selectedCensusTractData.length;
+    }
+    return null;
   }
 
-  /**
-   * Promise that resolves to an array of modal-split objects for the selected census-tracts
-   */
-  // TODO: Return either ACS (JTW) or CTPP (RJTW) modal splits based on isRJTW
-  @computed('isRJTW', 'analysis.{requiredJtwStudySelection.[],jtwStudySelection.[]}')
-  get selectedCensusTractData() {
-    const readonlyStore = this.get('readonlyStore');
-    const selectedIds = this.get('selectedCensusTractIds');
-    return this.isRJTW ? readonlyStore.findByIds('CTPP-modal-split', selectedIds) : readonlyStore.findByIds('ACS-modal-split', selectedIds);
-  }
 }

--- a/frontend/app/components/transportation/data-source-toggle.js
+++ b/frontend/app/components/transportation/data-source-toggle.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default class TransportationDataSourceToggleComponent extends Component {
+}

--- a/frontend/app/components/transportation/trip-generation-tables/modal-splits-vehicle-occupancy.js
+++ b/frontend/app/components/transportation/trip-generation-tables/modal-splits-vehicle-occupancy.js
@@ -1,0 +1,25 @@
+import Component from '@ember/component';
+import { computed } from '@ember-decorators/object';
+import { action } from '@ember-decorators/object';
+import { getAggregateValue } from '../../../helpers/get-aggregate-value';
+
+export default class TransportationTripGenerationTablesModalSplitsVehicleOccupancyComponent extends Component {
+
+  // The project's transportation analysis object.
+  // Must be passed from parent component.
+  analysis = {}
+
+  @action
+  saveAnalysis(){
+    this.analysis.save();
+  }
+
+  @computed('selectedCensusTractData')
+  get vehicleOccupancy() {
+    if(this.selectedCensusTractData){
+      return getAggregateValue([this.selectedCensusTractData, ["vehicle_occupancy"]]) / this.selectedCensusTractData.length;
+    }
+    return null;
+  }
+
+}

--- a/frontend/app/components/transportation/trip-generation-tables/trip-generation-rates.js
+++ b/frontend/app/components/transportation/trip-generation-tables/trip-generation-rates.js
@@ -1,0 +1,27 @@
+import Component from '@ember/component';
+import { action } from '@ember-decorators/object';
+
+export default class TransportationTripGenerationTablesTripGenerationRatesComponent extends Component {
+
+  // The project's transportation analysis object.
+  // Must be passed from parent component.
+  analysis = {}
+
+  /**
+   * @param {string} time - either "am", "md", "pm" or "saturday"
+   * @param {string} inOut - either "in" or "out"
+  */
+  @action
+  setInOutDist(time, inOut){
+    let dists = this.analysis.inOutDists;
+    if(dists[time][inOut] > 100){
+      this.analysis.set('inOutDists.'+time+'.'+inOut, 100);
+    }
+    if(dists[time][inOut] < 0){
+      this.analysis.set('inOutDists.'+time+'.'+inOut, 0);
+    }
+    let oppositeDir = (inOut == "in") ? "out" : "in";
+    this.analysis.set('inOutDists.'+time+'.'+oppositeDir, 100 - dists[time][inOut]);
+    this.analysis.save();
+  }
+}

--- a/frontend/app/components/transportation/trip-generation-tables/trip-generation-results.js
+++ b/frontend/app/components/transportation/trip-generation-tables/trip-generation-results.js
@@ -1,0 +1,350 @@
+import Component from '@ember/component';
+import { computed } from '@ember-decorators/object';
+import { getAggregatePercent } from '../../../helpers/get-aggregate-percent';
+import { getAggregateValue } from '../../../helpers/get-aggregate-value';
+
+
+export default class TransportationTripGenerationTablesTripGenerationResultsComponent extends Component {
+
+  // the Transportation Analysis model belonging to the Project model
+  analysis = {}
+  /**
+   * @param {Object[]} -- Array of modal splits
+  */
+  selectedCensusTractData = []
+  /**
+   * @param {Object} -- Hash where mode variable codes are keys and  and human readable labels are values
+  */
+  modeLookup = {}
+  /**
+   * @param {string[]} -- items must correspond to one of the variable modes defined in 
+   * app/utils/VARIABLE_MODE_LOOKUP
+  */
+  modalSplitVariablesSubset = [];
+
+  @computed('selectedCensusTractData', 'modalSplitVariablesSubset', 'modeLookup')
+  get modeAggregatePercents() {
+    let modeAggPercents = {};
+    for(let mode of this.modalSplitVariablesSubset){
+      modeAggPercents[mode] = getAggregatePercent([this.selectedCensusTractData, [mode], false]) / 100;
+    }
+    return modeAggPercents;
+  }
+
+  /** PERSON TRIPS **/
+
+  // trip gen result for given weekday time, direction and mode
+  @computed('modeAggregatePercents', 'modalSplitVariablesSubset', 'analysis.{residentialUnits,dailyTripRate.weekday.rate,temporalDistributions.decimal,inOutDists}')
+  get weekdayModeCalcs(){
+    let ta = this.analysis;
+    let weekdayModeCalcs = {
+      am: { in: {}, out: {}, },
+      md: { in: {}, out: {}, },
+      pm: { in: {}, out: {}, },
+    };
+    for(let time of ['am', 'md', 'pm']){
+      for(let inOut of ['in', 'out']){
+        for(let mode of this.modalSplitVariablesSubset){
+          weekdayModeCalcs[time][inOut][mode] = ta.residentialUnits *
+            ta.dailyTripRate.weekday.rate *
+            ta.temporalDistributions[time].decimal *
+            (ta.inOutDists[time][inOut] / 100) *
+            this.modeAggregatePercents[mode];
+        }
+      }
+    }
+    return  weekdayModeCalcs;
+  }
+
+  // totals of trip gen results across modes for a given weekday/time/inOut
+  @computed('weekdayModeCalcs', 'modalSplitVariablesSubset')
+  get weekdayModesTotals() {
+    let weekdayModesTotals = {
+      am: { in: {}, out: {}, },
+      md: { in: {}, out: {}, },
+      pm: { in: {}, out: {}, },
+    };
+    for(let time of ['am', 'md', 'pm']){
+      for(let inOut of ['in', 'out']){
+        weekdayModesTotals[time][inOut] = this.modalSplitVariablesSubset.reduce(
+          (acc, mode) => {
+            return acc += this.weekdayModeCalcs[time][inOut][mode];
+          }, 0)
+      }
+    }
+    return weekdayModesTotals;
+  }
+
+  // per-mode weekday totals.
+  // i.e. totals of trip gen results of both 'in' and 'out' directions for a given weekday time and mode
+  @computed('weekdayModeCalcs', 'modalSplitVariablesSubset')
+  get totalsOfWeekdayMode() {
+    let totalsOfWeekdayMode = {
+      am: {},
+      md: {},
+      pm: {},
+    };
+    for(let time of ['am', 'md', 'pm']){
+      for(let mode of this.modalSplitVariablesSubset){
+        totalsOfWeekdayMode[time][mode] = this.weekdayModeCalcs[time]['in'][mode] +
+          this.weekdayModeCalcs[time]['out'][mode]
+      }
+    }
+    return totalsOfWeekdayMode;
+  }
+
+  // total of trip gen results  across per-mode totals for a given weekday time
+  @computed('totalsOfWeekdayMode', 'modalSplitVariablesSubset')
+  get totalsOfTotalsOfWeekdayMode() {
+    let totalsOfTotalsOfWeekdayMode = {
+      am: null,
+      md: null,
+      pm: null,
+    };
+    for(let time of ['am', 'md', 'pm']){
+      totalsOfTotalsOfWeekdayMode[time] = this.modalSplitVariablesSubset.reduce(
+        (acc, mode) => {
+          return acc += this.totalsOfWeekdayMode[time][mode];
+        }, 0)
+    }
+    return totalsOfTotalsOfWeekdayMode;
+  }
+
+  @computed('modeAggregatePercents', 'modalSplitVariablesSubset', 'analysis.{residentialUnits,dailyTripRate.saturday.rate,temporalDistributions.decimal,inOutDists}')
+  get saturdayModeCalcs() {
+    let ta = this.analysis;
+    let saturdayModeCalcs = {
+      in: {}, out: {},
+    };
+    for(let inOut of ['in', 'out']){
+      for(let mode of this.modalSplitVariablesSubset){
+        saturdayModeCalcs[inOut][mode] = ta.residentialUnits *
+            ta.dailyTripRate.saturday.rate *
+            ta.temporalDistributions['saturday'].decimal *
+            (ta.inOutDists['saturday'][inOut] / 100) *
+            this.modeAggregatePercents[mode];
+      }
+    }
+    return  saturdayModeCalcs;
+  }
+
+  //totals of trip gen results across modes for a given saturday time/inOut
+  @computed('saturdayModeCalcs', 'modalSplitVariablesSubset')
+  get saturdayModesTotals() {
+    let saturdayModesTotals = {
+      in: {}, out: {},
+    };
+    for(let inOut of ['in', 'out']){
+      saturdayModesTotals[inOut] = this.modalSplitVariablesSubset.reduce(
+        (acc, mode) => {
+          return acc += this.saturdayModeCalcs[inOut][mode];
+        }, 0)
+    }
+    return saturdayModesTotals;
+  }
+
+  // per-mode saturday totals.
+  // i.e. total of both 'in' and 'out' directions for a given saturday and mode
+  @computed('saturdayModeCalcs', 'modalSplitVariablesSubset')
+  get totalsOfSaturdayMode() {
+    let totalsOfSaturdayMode = {
+      // keys of all modes in this.modalSplitVariablesSubset
+    };
+    for(let mode of this.modalSplitVariablesSubset){
+      totalsOfSaturdayMode[mode] = this.saturdayModeCalcs['in'][mode] +
+        this.saturdayModeCalcs['out'][mode];
+    }
+    return totalsOfSaturdayMode;
+  }
+
+  // total of trip gen results across per-mode totals for Saturday
+  @computed('totalsOfSaturdayMode')
+  get totalOfTotalsOfSaturdayMode() {
+    return this.modalSplitVariablesSubset.reduce(
+      (acc, mode) => {
+        return acc += this.totalsOfSaturdayMode[mode];
+      }, 0)
+  }
+
+  /** VEHICLE TRIPS **/
+
+  @computed('selectedCensusTractData')
+  get vehicleOccupancy() {
+    if(this.selectedCensusTractData){
+      return getAggregateValue([this.selectedCensusTractData, ["vehicle_occupancy"]]) / this.selectedCensusTractData.length;
+    }
+    return null;
+  }
+
+  @computed('weekdayModeCalcs', 'vehicleOccupancy')
+  get weekdayAutoVehicleTripCalcs() {
+    let weekdayAutoVehicleTripCalcs = {
+      am: { in: {}, out: {}, },
+      md: { in: {}, out: {}, },
+      pm: { in: {}, out: {}, },
+    };
+    for(let time of ['am', 'md', 'pm']){
+      for(let inOut of ['in', 'out']){
+        if(!isNaN(this.weekdayModeCalcs[time][inOut].trans_auto_total)){
+          weekdayAutoVehicleTripCalcs[time][inOut] = this.weekdayModeCalcs[time][inOut].trans_auto_total  / this.vehicleOccupancy;
+        }
+      }
+    }
+    return weekdayAutoVehicleTripCalcs;
+  }
+
+  @computed('weekdayModeCalcs', 'analysis.taxiVehicleOccupancy')
+  get weekdayTaxiVehicleTripCalcs() {
+    if(this.analysis.taxiVehicleOccupancy){
+      let weekdayTaxiVehicleTripCalcs = {
+        am: { in: null, out: null, },
+        md: { in: null, out: null, },
+        pm: { in: null, out: null, },
+      };
+      for(let time of ['am', 'md', 'pm']){
+        for(let inOut of ['in', 'out']){
+          if(!isNaN(this.weekdayModeCalcs[time][inOut].trans_taxi)){
+            weekdayTaxiVehicleTripCalcs[time][inOut] = this.weekdayModeCalcs[time][inOut].trans_taxi  / this.analysis.taxiVehicleOccupancy;
+          }
+        }
+      }
+      return weekdayTaxiVehicleTripCalcs;
+    }
+    return null;
+  }
+
+  @computed('weekdayAutoVehicleTripCalcs', 'weekdayTaxiVehicleTripCalcs', 'analysis.taxiVehicleOccupancy')
+  get weekdayVehicleTripTotals() {
+    if(this.analysis.taxiVehicleOccupancy){
+      let weekdayVehicleTripTotals = {
+        am: { in: {}, out: {}, },
+        md: { in: {}, out: {}, },
+        pm: { in: {}, out: {}, },
+      };
+      for(let time of ['am', 'md', 'pm']){
+        for(let inOut of ['in', 'out']){
+          weekdayVehicleTripTotals[time][inOut] = this.weekdayAutoVehicleTripCalcs[time][inOut] +
+            this.weekdayTaxiVehicleTripCalcs[time][inOut];
+        }
+      }
+      return weekdayVehicleTripTotals;
+    }
+    return null;
+  }
+
+  @computed('weekdayAutoVehicleTripCalcs')
+  get totalsOfWeekdayAutoVehicleTrip() {
+    let totalsOfWeekdayAutoVehicleTrip = {
+      am: null,
+      md: null,
+      pm: null,
+    };
+    for(let time of ['am', 'md', 'pm']){
+      totalsOfWeekdayAutoVehicleTrip[time] = this.weekdayAutoVehicleTripCalcs[time]['in'] + 
+      this.weekdayAutoVehicleTripCalcs[time]['out']
+    }
+    return totalsOfWeekdayAutoVehicleTrip;
+  }
+
+  @computed('weekdayTaxiVehicleTripCalcs')
+  get totalsOfWeekdayTaxiVehicleTrip() {
+    if(this.analysis.taxiVehicleOccupancy){
+      let totalsOfWeekdayTaxiVehicleTrip = {
+        am: null,
+        md: null,
+        pm: null,
+      };
+      for(let time of ['am', 'md', 'pm']){
+        totalsOfWeekdayTaxiVehicleTrip[time] = this.weekdayTaxiVehicleTripCalcs[time]['in'] + 
+        this.weekdayTaxiVehicleTripCalcs[time]['out']
+      }
+      return totalsOfWeekdayTaxiVehicleTrip;
+    }
+    return null;
+  }
+
+  @computed('totalsOfWeekdayAutoVehicleTrip', 'totalsOfWeekdayTaxiVehicleTrip', 'analysis.taxiVehicleOccupancy')
+  get totalsOfTotalsOfWeekdayVehicleTrip() {
+    if(this.analysis.taxiVehicleOccupancy){
+      let totalsOfTotalsOfWeekdayVehicleTrip = {
+        am: null,
+        md: null,
+        pm: null,
+      };
+      for(let time of ['am', 'md', 'pm']){
+        totalsOfTotalsOfWeekdayVehicleTrip[time] = this.totalsOfWeekdayAutoVehicleTrip[time] +
+          this.totalsOfWeekdayTaxiVehicleTrip[time];
+      }
+      return totalsOfTotalsOfWeekdayVehicleTrip;
+    }
+    return null;
+  }
+
+  @computed('saturdayModeCalcs', 'vehicleOccupancy')
+  get saturdayAutoVehicleTripCalcs() {
+    let saturdayAutoVehicleTripCalcs = {
+      in: null,
+      out: null,
+    }
+    for(let inOut of ['in', 'out']){
+      if(!isNaN(this.saturdayModeCalcs[inOut].trans_auto_total)){
+        saturdayAutoVehicleTripCalcs[inOut] = this.saturdayModeCalcs[inOut].trans_auto_total  / this.vehicleOccupancy;
+      }
+    }
+    return saturdayAutoVehicleTripCalcs;
+  }
+
+  @computed('saturdayModeCalcs', 'analysis.taxiVehicleOccupancy')
+  get saturdayTaxiVehicleTripCalcs(){
+    if(this.analysis.taxiVehicleOccupancy){
+      let saturdayTaxiVehicleTripCalcs = {
+        in: null,
+        out: null,
+      }
+      for(let inOut of ['in', 'out']){
+        if(!isNaN(this.saturdayModeCalcs[inOut].trans_taxi)){
+          saturdayTaxiVehicleTripCalcs[inOut] = this.saturdayModeCalcs[inOut].trans_taxi  / this.analysis.taxiVehicleOccupancy;
+        }
+      }
+      return saturdayTaxiVehicleTripCalcs;
+    }
+    return null;
+  }
+
+  @computed('saturdayAutoVehicleTripCalcs', 'saturdayTaxiVehicleTripCalcs', 'analysis.taxiVehicleOccupancy')
+  get saturdayVehicleTripTotals() {
+    if(this.analysis.taxiVehicleOccupancy){
+      let saturdayVehicleTripTotals = {
+        in: {}, out: {},
+      };
+      for(let inOut of ['in', 'out']){
+        saturdayVehicleTripTotals[inOut] = this.saturdayAutoVehicleTripCalcs[inOut] +
+          this.saturdayTaxiVehicleTripCalcs[inOut];
+      }
+      return saturdayVehicleTripTotals;
+    }
+    return null;
+  }
+
+  @computed('saturdayAutoVehicleTripCalcs')
+  get totalOfSaturdayAutoVehicleTrip() {
+    return this.saturdayAutoVehicleTripCalcs.in + this.saturdayAutoVehicleTripCalcs.out;
+  }
+
+  @computed('saturdayTaxiVehicleTripCalcs')
+  get totalOfSaturdayTaxiVehicleTrip() {
+    if(this.analysis.taxiVehicleOccupancy){
+      return this.saturdayTaxiVehicleTripCalcs.in + this.saturdayTaxiVehicleTripCalcs.out;
+    }
+    return null;
+  }
+
+  @computed('totalOfSaturdayAutoVehicleTrip', 'totalOfSaturdayTaxiVehicleTrip')
+  get totalOfTotalsOfSaturdayVehicleTrip() {
+    if(this.totalOfSaturdayTaxiVehicleTrip){
+      return this.totalOfSaturdayAutoVehicleTrip + this.totalOfSaturdayTaxiVehicleTrip;
+    }
+    return null;
+  }
+
+}

--- a/frontend/app/controllers/project/show/transportation.js
+++ b/frontend/app/controllers/project/show/transportation.js
@@ -1,7 +1,5 @@
 import Controller from '@ember/controller';
-import { alias } from '@ember-decorators/object/computed';
 
 export default class ProjectShowTransportationController extends Controller {
-  @alias('model.project') project;
-  @alias('model.transportationAnalysis') analysis;
+  // parentCtrl property set within the route.
 }

--- a/frontend/app/controllers/project/show/transportation/existing-conditions.js
+++ b/frontend/app/controllers/project/show/transportation/existing-conditions.js
@@ -1,0 +1,43 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember-decorators/service';
+import { computed } from '@ember-decorators/object';
+import { VARIABLE_MODE_LOOKUP, COMMUTER_VARIABLES, MODAL_SPLIT_VARIABLES_SUBSET } from '../../../../utils/modalSplit';
+import { alias } from '@ember-decorators/object/computed';
+
+export default class ProjectShowTransportationExistingConditionsController extends Controller {
+
+  @service store;
+  @service('readonly-ceqr-data-store') readonlyStore;
+
+  commuterModes = COMMUTER_VARIABLES;
+  modeLookup = VARIABLE_MODE_LOOKUP;
+
+  modalSplitVariablesSubset = MODAL_SPLIT_VARIABLES_SUBSET;
+
+  isRJTW = false;
+
+  @alias('model.transportationAnalysis') analysis;
+
+  /**
+   * Composite array containing geoids of all selected census tracts
+   */
+  @computed('analysis.{requiredJtwStudySelection.[],jtwStudySelection.[]}')
+  get selectedCensusTractIds() {
+    if(this.model){
+      return [...this.analysis.jtwStudySelection, ...this.analysis.requiredJtwStudySelection];
+    }
+    return [];
+  }
+
+  /**
+   * Promise that resolves to an array of modal-split objects for the selected census-tracts
+   */
+  @computed('isRJTW', 'analysis.{requiredJtwStudySelection.[],jtwStudySelection.[]}')
+  get selectedCensusTractData() {
+    const readonlyStore = this.get('readonlyStore');
+    const selectedIds = this.get('selectedCensusTractIds');
+    let selectedData = this.isRJTW ? readonlyStore.findByIds('CTPP-modal-split', selectedIds) : readonlyStore.findByIds('ACS-modal-split', selectedIds);
+    return selectedData;
+  }
+
+}

--- a/frontend/app/helpers/get-aggregate-percent.js
+++ b/frontend/app/helpers/get-aggregate-percent.js
@@ -1,14 +1,20 @@
 import { helper } from '@ember/component/helper';
 
 /** 
- * Helper for CensusTractsTable component that calculates an aggregate modal split percent 
+ * Helper that calculates an aggregate modal split percent 
  * for a full set of modal split data for all census tracts in a study selection.
  * Accepts multiple variables, so modal splits for a random subset of modes can be calculated.
+ * @param {Object[]} allModalSplitData - array of Census Tract ModalSplits
+ * @param {String[]} variables - array of mode variable codes 
+ * @param {Bool} includePctSign -- set to True to return a string with % symbol appended.
+ * False for integer value. Defaults to True;
  */
 export function getAggregatePercent(params/*, hash*/) {
-  const [allModalSplitData, variables] = params;
+  let [allModalSplitData, variables, includePctSign] = params;
 
-  if(allModalSplitData && Array.isArray(allModalSplitData) && variables && Array.isArray(variables)) {
+  if (includePctSign == null) includePctSign = true;
+
+  if (allModalSplitData && Array.isArray(allModalSplitData) && variables && Array.isArray(variables)) {
     // calculate the aggregate of the sums of given variables for all modal splits
     const partTotal = allModalSplitData.reduce((runningSum, modalSplit) => {
       return runningSum + variables.reduce((runningSum, variable) => {
@@ -25,7 +31,7 @@ export function getAggregatePercent(params/*, hash*/) {
     const percent = (partTotal/wholeTotal) * 100;
 
     // return formatted percent 
-    return isNaN(percent) ? '-' : `${percent.toFixed(1)} %`;
+    return isNaN(percent) ? '-' : ((includePctSign) ? `${percent.toFixed(1)} %` : percent.toFixed(1));
   }
 }
 

--- a/frontend/app/helpers/get-aggregate-percent.js
+++ b/frontend/app/helpers/get-aggregate-percent.js
@@ -24,7 +24,10 @@ export function getAggregatePercent(params/*, hash*/) {
 
     // calculate the aggregate total for all modal splits
     const wholeTotal = allModalSplitData.reduce((runningSum, modalSplit) => {
-      return runningSum + modalSplit.trans_commuter_total.value;
+      // TODO: Write some alert for if any mode variables have undefined value?
+      // Also, investigate whether users would like the wholeTotal to be invalidated if there's a modalSplit
+      // with missing trans_commuter_total value.
+      return modalSplit.trans_commuter_total ? runningSum + modalSplit.trans_commuter_total.value : runningSum;
     }, 0);
 
     // calculate to percent

--- a/frontend/app/helpers/get-split-percent.js
+++ b/frontend/app/helpers/get-split-percent.js
@@ -14,7 +14,7 @@ export function getSplitPercent(params/*, hash*/) {
         }
       , 0);
     // calculate percent
-    const percent = (partTotal / modalSplitData.trans_commuter_total.value) * 100;
+    const percent = modalSplitData.trans_commuter_total ? (partTotal / modalSplitData.trans_commuter_total.value) * 100 : undefined;
 
     // return formatted percent 
     return isNaN(percent) ? '-' : `${percent.toFixed(1)} %`;

--- a/frontend/app/models/transportation-analysis.js
+++ b/frontend/app/models/transportation-analysis.js
@@ -15,6 +15,10 @@ export default class TransportationAnalysisModel extends Model {
   @attr({defaultValue: () => []}) jtwStudySelection;
   // the computed centroid of the study selection
   @attr({defaultValue: () => []}) jtwStudyAreaCentroid;
+  // The percentage values for trip generation per-peak-hour In and Out trip distributions
+  @attr({defaultValue: () => {}}) inOutDists;
+  // User-entered taxi vehicle occupancy rate for "trip generation" existing conditions step
+  @attr({defaultValue: () => null}) taxiVehicleOccupancy;
 
   // Detailed Analysis trigger
   @computed(
@@ -199,4 +203,28 @@ export default class TransportationAnalysisModel extends Model {
   ratioFor(type) {
     return this.get(type) / this.thresholdFor(type);
   }
+
+  /**
+   *  Existing Conditions > Trip Generation variables
+  **/ 
+
+  // Constants defined by the Technical Manual, Chapter 16 pg. 5
+  get dailyTripRate() {
+    const dtrConstants = {
+      weekday:  {label: "Weekday", rate:  8.075},
+      saturday: {label: "Saturday", rate: 9.6}
+    }
+    return dtrConstants;
+  }
+
+  get temporalDistributions() {
+    const tdConstants = {
+      am:       {label: "AM",       percent: 10, decimal: .10 },
+      md:       {label: "MD",       percent: 5,  decimal: .05 },
+      pm:       {label: "PM",       percent: 11, decimal: .11 },
+      saturday: {label: "Saturday", percent: 8,  decimal: .08 }
+    }
+    return tdConstants;
+  }
+
 }

--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -36,6 +36,10 @@ Router.map(function() {
 
   this.route('project', function() {
     this.route('new');
+    // we avoided using an underscore (:_id) specifically to
+    // not trigger default model lookup for the project/show route.
+    // See routes/project/show.js for custom .findRecord() call to include
+    // related resources.
     this.route('show', {path: '/:id'}, function() {
       this.route('edit');
 

--- a/frontend/app/routes/project/show/transportation.js
+++ b/frontend/app/routes/project/show/transportation.js
@@ -1,16 +1,12 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 
 export default class ProjectShowTransportationRoute extends Route {
-  controllerName = 'project';
-  
-  async model() {
+
+  async setupController(controller) {
     const { project } = this.modelFor('project/show');
     const transportationAnalysis = await project.get('transportationAnalysis');
 
-    return RSVP.hash({
-      project,
-      transportationAnalysis
-    });
+    controller.set('model', { project, transportationAnalysis });
+    controller.set('projectCtrl', this.controllerFor('project'));
   }
 }

--- a/frontend/app/routes/project/show/transportation/existing-conditions.js
+++ b/frontend/app/routes/project/show/transportation/existing-conditions.js
@@ -1,9 +1,16 @@
 import Route from '@ember/routing/route';
 
 export default class ProjectShowTransportationExistingConditionsRoute extends Route {
-  controllerName = 'project';
 
   redirect(model) {
-    this.transitionTo('project.show.transportation.existing-conditions.census-tracts', model.project.id);
+    this.transitionTo('project.show.transportation.existing-conditions.census-tracts', model);
+  }
+
+  // sets up existing-conditions controller after redirect to `census-tracts` child route
+  async setupController(controller) {
+    const { project } = this.modelFor('project/show');
+    const transportationAnalysis = await project.get('transportationAnalysis');
+
+    controller.set('model', { project, transportationAnalysis });
   }
 }

--- a/frontend/app/routes/project/show/transportation/existing-conditions/census-tracts.js
+++ b/frontend/app/routes/project/show/transportation/existing-conditions/census-tracts.js
@@ -1,18 +1,18 @@
 import Route from '@ember/routing/route';
 
 export default class ProjectShowTransportationExistingConditionsCensusTractsRoute extends Route {
-  controllerName = 'project';
+  ctrlName = 'project/show/transportation/existing-conditions';
 
   renderTemplate() {
     this.render('project/show/transportation/existing-conditions/census-tracts/map', {
       into: 'project/show/transportation/existing-conditions',
       outlet: 'map',
-      controller: this.controllerName
+      controller: this.ctrlName
     })
     this.render('project/show/transportation/existing-conditions/census-tracts/table', {
       into: 'project/show/transportation/existing-conditions',
       outlet: 'table',
-      controller: this.controllerName
+      controller: this.ctrlName
     })
   }
 }

--- a/frontend/app/routes/project/show/transportation/existing-conditions/journey-to-work.js
+++ b/frontend/app/routes/project/show/transportation/existing-conditions/journey-to-work.js
@@ -1,18 +1,18 @@
 import Route from '@ember/routing/route';
 
 export default class ProjectShowTransportationExistingConditionsJourneyToWorkRoute extends Route {
-  controllerName = 'project';
+  ctrlName = 'project/show/transportation/existing-conditions';
 
   renderTemplate() {
     this.render('project/show/transportation/existing-conditions/journey-to-work/map', {
       into: 'project/show/transportation/existing-conditions',
       outlet: 'map',
-      controller: this.controllerName
+      controller: this.ctrlName
     })
     this.render('project/show/transportation/existing-conditions/journey-to-work/table', {
       into: 'project/show/transportation/existing-conditions',
       outlet: 'table',
-      controller: this.controllerName
+      controller: this.ctrlName
     })
   }
 }

--- a/frontend/app/routes/project/show/transportation/existing-conditions/trip-generation.js
+++ b/frontend/app/routes/project/show/transportation/existing-conditions/trip-generation.js
@@ -1,18 +1,18 @@
 import Route from '@ember/routing/route';
 
 export default class ProjectShowTransportationExistingConditionsTripGenerationRoute extends Route {
-  controllerName = 'project';
+  ctrlName = 'project/show/transportation/existing-conditions';
 
   renderTemplate() {
     this.render('project/show/transportation/existing-conditions/trip-generation/map', {
       into: 'project/show/transportation/existing-conditions',
       outlet: 'map',
-      controller: this.controllerName
+      controller: this.ctrlName
     })
     this.render('project/show/transportation/existing-conditions/trip-generation/table', {
       into: 'project/show/transportation/existing-conditions',
       outlet: 'table',
-      controller: this.controllerName
+      controller: this.ctrlName
     })
   }
 }

--- a/frontend/app/templates/components/transportation/analysis-steps.hbs
+++ b/frontend/app/templates/components/transportation/analysis-steps.hbs
@@ -14,7 +14,7 @@
     </div>
   {{/link-to}}
   {{#link-to
-    "project.show.transportation.existing-conditions.census-tracts"
+    "project.show.transportation.existing-conditions"
     project.id
     class="step"
   }}

--- a/frontend/app/templates/components/transportation/census-tracts-table.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-table.hbs
@@ -1,85 +1,81 @@
-<div class="ui basic top attached segment">
-  <div class="ui secondary menu">
-    <a
-      class="item {{unless this.isRJTW "active"}}"
-      data-test-censustracts-table-isrjtw="false"
-      {{action (mut this.isRJTW) false}}
-    >
-      Journey To Work
-    </a>
-    <a
-      class="item {{if this.isRJTW "active"}}"
-      data-test-censustracts-table-isrjtw="true"
-      {{action (mut this.isRJTW) true}}
-    >
-      Reverse Journey To Work
-    </a>
-  </div>
-</div>
-<div style="overflow-x: scroll;">
-  <table class="ui celled table">
-    <thead>
-      <tr>
-        <th style="min-width: 220px;"> </th>
-        {{#each this.selectedCensusTractIds as |censusTract|}}
+{{#if (await this.selectedCensusTractData)}}
+  <div style="overflow-x: scroll;">
+    <table class="ui celled table">
+      <thead>
+        <tr>
+          <th class="two wide" style="min-width: 220px;" rowspan="2">
+          </th>
           <th class="two wide" colspan="2">
-            {{human-readable-census-tract censusTract}}
+            Total
           </th>
-        {{/each}}
-        <th class="two wide" colspan="2">
-          Total
-        </th>
-      </tr>
-      <tr>
-        <th style="width: 220px;"> </th>
-        {{#each this.selectedCensusTractIds as |censusTract|}}
+          {{#each this.selectedCensusTractIds as |censusTract|}}
+            <th class="two wide" colspan="2">
+              {{human-readable-census-tract censusTract}}
+            </th>
+          {{/each}}
+        </tr>
+        <tr>
           <th class="one wide" colspan="1">
             Count
           </th>
           <th class="one wide" colspan="1">
             Percent
           </th>
-        {{/each}}
-          <th class="one wide" colspan="1">
-            Count
-          </th>
-          <th class="one wide" colspan="1">
-            Percent
-          </th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#let (await this.selectedCensusTractData) as |censusTracts|}}
-        {{#each this.commuterModes as |mode|}}
+          {{#each this.selectedCensusTractIds as |censusTract|}}
+            <th class="one wide" colspan="1">
+              Count
+            </th>
+            <th class="one wide" colspan="1">
+              Percent
+            </th>
+          {{/each}}
+        </tr>
+      </thead>
+      <tbody>
+        {{#let this.selectedCensusTractData as |censusTracts|}}
+          {{#each this.commuterModes as |mode|}}
+            <Transportation::CensusTractsTable::ValueAndPercentRow
+              @title={{get this.modeLookup mode}}
+              @allModalSplitData={{censusTracts}}
+              @variables={{array mode}}
+            />
+          {{/each}}
           <Transportation::CensusTractsTable::ValueAndPercentRow
-            @title={{get this.modeLookup mode}}
+            @title={{get this.modeLookup "trans_total"}}
             @allModalSplitData={{censusTracts}}
-            @variables={{array mode}}
+            @variables={{array "trans_total"}}
           />
-        {{/each}}
-        <Transportation::CensusTractsTable::ValueAndPercentRow
-          @title={{get this.modeLookup "trans_total"}}
-          @allModalSplitData={{censusTracts}}
-          @variables={{array "trans_total"}}
-        />
-        <Transportation::CensusTractsTable::ValueAndPercentRow
-          @title={{get this.modeLookup "trans_commuter_total"}}
-          @allModalSplitData={{censusTracts}}
-          @variables={{array "trans_commuter_total"}}
-        />
-        <Transportation::CensusTractsTable::ValueAndPercentRow
-          @title={{if this.isRJTW "Workers" "Population"}}
-          @allModalSplitData={{censusTracts}}
-          @variables={{array (if this.isRJTW "workers" "population")}}
-          data-test-censustracts-table-baseunit
-        />
-        <Transportation::CensusTractsTable::ValueAndPercentRow
-          @title={{get this.modeLookup "vehicle_occupancy"}}
-          @allModalSplitData={{censusTracts}}
-          @variables={{array "vehicle_occupancy"}}
-          @noPercent=true
-        />
-      {{/let}}
-    </tbody>
-  </table>
-</div>
+          <Transportation::CensusTractsTable::ValueAndPercentRow
+            @title={{get this.modeLookup "trans_commuter_total"}}
+            @allModalSplitData={{censusTracts}}
+            @variables={{array "trans_commuter_total"}}
+          />
+          <Transportation::CensusTractsTable::ValueAndPercentRow
+            @title={{if this.isRJTW "Workers" "Population"}}
+            @allModalSplitData={{censusTracts}}
+            @variables={{array (if this.isRJTW "workers" "population")}}
+            data-test-censustracts-table-baseunit
+          />
+          <tr style="background-color: rgb(249, 250, 251)">
+            <td></td>
+            <td colspan="2">Average</td>
+            <td colspan="{{mult censusTracts.length 2}}"></td>
+          </tr>
+          <tr>
+            <td>&nbsp;&nbsp;&nbsp;Vehicle Occupancy</td>
+            <td>{{round this.vehicleOccupancyAvg decimals=2}}</td>
+            <td>
+              -
+            </td>
+            {{#each censusTracts as |modalSplit|}}
+              <td>{{get-split-value modalSplit (array "vehicle_occupancy") true}}</td>
+              <td>
+                  -
+              </td>
+            {{/each}}
+          </tr>
+        {{/let}}
+      </tbody>
+    </table>
+  </div>
+{{/if}}

--- a/frontend/app/templates/components/transportation/census-tracts-table/value-and-percent-row.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-table/value-and-percent-row.hbs
@@ -1,4 +1,12 @@
 <td>&nbsp;&nbsp;&nbsp;{{this.title}}</td>
+<td>{{round (get-aggregate-value this.allModalSplitData this.variables) decimals=2}}</td>
+<td>
+  {{#if noPercent}}
+    -
+  {{else}}
+    {{get-aggregate-percent this.allModalSplitData this.variables true}}
+  {{/if}}
+</td>
 {{#each this.allModalSplitData as |modalSplit|}}
   <td>{{get-split-value modalSplit this.variables.firstObject true}}</td>
   <td>
@@ -9,11 +17,3 @@
     {{/if}}
   </td>
 {{/each}}
-<td>{{get-aggregate-value this.allModalSplitData this.variables}}</td>
-<td>
-  {{#if noPercent}}
-    -
-  {{else}}
-    {{get-aggregate-percent this.allModalSplitData this.variables}}
-  {{/if}}
-</td>

--- a/frontend/app/templates/components/transportation/data-source-toggle.hbs
+++ b/frontend/app/templates/components/transportation/data-source-toggle.hbs
@@ -1,0 +1,18 @@
+<div class="ui basic top attached segment">
+  <div class="ui secondary menu">
+    <a
+      class="item {{unless this.switch "active"}}"
+      data-test-censustracts-table-isrjtw="false"
+      {{action (mut this.switch) false}}
+    >
+      {{this.falseLabel}}
+    </a>
+    <a
+      class="item {{if this.switch "active"}}"
+      data-test-censustracts-table-isrjtw="true"
+      {{action (mut this.switch) true}}
+    >
+      {{this.trueLabel}}
+    </a>
+  </div>
+</div>

--- a/frontend/app/templates/components/transportation/trip-generation-tables/modal-splits-vehicle-occupancy.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-tables/modal-splits-vehicle-occupancy.hbs
@@ -1,0 +1,65 @@
+<div class="ui sixteen column grid">
+  <div class="sixteen wide column">
+    <div class="ui top clearing segment">
+      <h4 class="ui left floated header">
+        <div class="content">
+          Modal Splits and Vehicle Occupancy
+        </div>
+      </h4>
+    </div>
+  </div>
+  <div class="eight wide column">
+    <table class="ui celled table">
+      <thead>
+        <tr>
+          <th colspan="2" class="two wide">
+            Modal Split
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each this.modalSplitVariablesSubset as |mode|}}
+          <tr>
+            <td>
+              {{get this.modeLookup mode}}
+            </td>
+            <td>
+              {{get-aggregate-percent this.selectedCensusTractData (array mode)}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+  <div class="eight wide column">
+    <table class="ui celled table">
+      <thead>
+        <tr>
+          <th colspan="2" class="two wide">
+            Vehicle Occupancy
+          </th>
+        </tr>
+        <tr>
+          <th class="one wide">
+            Auto
+          </th>
+          <th class="taxi wide">
+            Taxi
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+          <tr>
+            <td>
+              {{round this.vehicleOccupancy decimals=2}}
+            </td>
+            <td>
+              <div class="ui input edit-cell">
+                {{input type="number" min=0 value=this.analysis.taxiVehicleOccupancy change=(action "saveAnalysis")}}
+              </div>
+            </td>
+          </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/frontend/app/templates/components/transportation/trip-generation-tables/trip-generation-rates.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-tables/trip-generation-rates.hbs
@@ -1,0 +1,140 @@
+<div class="ui top attached clearing segment">
+  <h4 class="ui left floated header">
+    <div class="content">
+      Trip Generation Rates
+    </div>
+  </h4>
+</div>
+<table class="ui attached celled table">
+  <thead>
+    <tr>
+      <th class="one wide">
+        Residential Units
+      </th>
+      <th colspan="7" class="four wide">
+        Person Trip
+      </th>
+    </tr>
+    <tr>
+      <th class="one wide">
+      </th>
+      <th colspan="2" class="one wide">
+        Daily Trip Rate
+      </th>
+      <th class="one wide">
+        Peak Hour
+      </th>
+      <th clas="one wide">
+        Temporal
+      </th>
+      <th clas="three wide">
+        In
+      </th>
+      <th clas="three wide">
+        Out
+      </th>
+      <th clas="one wide">
+        Total
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="6">
+        {{analysis.residentialUnits}}<br>
+        (DU)
+      </td>
+      <td rowspan="3">{{analysis.dailyTripRate.weekday.label}}</td>
+      <td rowspan="3">{{analysis.dailyTripRate.weekday.rate}}</td>
+      <td>{{analysis.temporalDistributions.am.label}}</td>
+      <td>{{analysis.temporalDistributions.am.percent}}</td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.am.in change=(action "setInOutDist" "am" "in")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.am.out change=(action "setInOutDist" "am" "out")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>100%</td>
+    </tr>
+    <tr>
+      <td>{{analysis.temporalDistributions.md.label}}</td>
+      <td>{{analysis.temporalDistributions.md.percent}}</td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.md.in change=(action "setInOutDist" "md" "in")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.md.out change=(action "setInOutDist" "md" "out")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>100%</td>
+    </tr>
+    <tr>
+      <td>{{analysis.temporalDistributions.pm.label}}</td>
+      <td>{{analysis.temporalDistributions.pm.percent}}</td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.pm.in change=(action "setInOutDist" "pm" "in")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.pm.out change=(action "setInOutDist" "pm" "out")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>100%</td>
+    </tr>
+    <tr>
+      <td>{{analysis.dailyTripRate.saturday.label}}</td>
+      <td>{{analysis.dailyTripRate.saturday.rate}}</td>
+      <td>{{analysis.temporalDistributions.saturday.label}}</td>
+      <td>{{analysis.temporalDistributions.saturday.percent}}</td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.saturday.in change=(action "setInOutDist" "saturday" "in")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>
+        <div class="ui input fluid right labeled edit-cell">
+          {{input type="number" min=0 max=100 value=analysis.inOutDists.saturday.out change=(action "setInOutDist" "saturday" "out")}}
+          <div class="ui basic label">
+            %
+          </div>
+        </div>
+      </td>
+      <td>100%</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>&#47;DU</td>
+      <td colspan="5"></td>
+    </tr>
+  </tbody>
+</table>

--- a/frontend/app/templates/components/transportation/trip-generation-tables/trip-generation-results.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-tables/trip-generation-results.hbs
@@ -1,0 +1,195 @@
+<div class="ui top attached clearing segment">
+  <h4 class="ui left floated header">
+    <div class="content">
+      Trip Generation Results
+    </div>
+  </h4>
+</div>
+<div style="overflow-x: scroll;">
+  <table class="ui attached celled table">
+    <thead>
+      <tr>
+        <th colspan="2">
+        </th>
+        <th colspan="6">
+          Person Trip
+        </th>
+        <th colspan="4">
+          Vehicle Trip
+        </th>
+      </tr>
+      <tr>
+        <th class="one wide">
+          Peak Hour
+        </th>
+        <th class="one wide">
+          In/Out
+        </th>
+        {{#each this.modalSplitVariablesSubset as |mode|}}
+          <th>
+            {{get this.modeLookup mode}}
+          </th>
+        {{/each}}
+        <th>
+          Total
+        </th>
+        <th>
+          Auto
+        </th>
+        <th>
+          Taxi
+        </th>
+        <th>
+          Delivery
+        </th>
+        <th>
+          Total
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#if (await this.selectedCensusTractData)}}
+        {{#each-in this.analysis.temporalDistributions as |time timeInfo|}}
+          {{#each (array (hash key='in' label="In") (hash key='out' label="Out") (hash key='total' label="Total")) as |inOutOrTotal idx|}}
+            <tr>
+              {{#if (is-equal idx 0)}}
+                <td rowspan="3">{{timeInfo.label}}</td>
+              {{/if}}
+              <td>{{inOutOrTotal.label}}</td>
+              {{#with (hash
+                  trans_auto_total=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_auto_total') false) 100)
+                  trans_taxi=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_taxi') false) 100)
+                  trans_public_bus=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_public_bus') false) 100)
+                  trans_public_subway=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_public_subway') false) 100)
+                  trans_walk=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_walk') false) 100)
+                  vehicle_occupancy=(get-aggregate-value this.selectedCensusTractData (array 'vehicle_occupancy'))
+              ) as |modeAggPcts|}}
+                {{#with this.analysis as |ta|}}
+                  {{#with (div (get (get ta.temporalDistributions time) 'percent') 100) as |temporalDistPct|}}
+                    {{#if (and (not-eq time "saturday") (not-eq inOutOrTotal.key "total"))}}
+                      {{#each this.modalSplitVariablesSubset as |mode|}}
+                        <td>
+                          {{round (get (get (get this.weekdayModeCalcs time) inOutOrTotal.key) mode)}}
+                        </td>
+                      {{/each}}
+                      <td>
+                        {{round (get (get this.weekdayModesTotals time) inOutOrTotal.key)}}
+                      </td>
+                      <td>
+                        {{round (get (get this.weekdayAutoVehicleTripCalcs time) inOutOrTotal.key)}}
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round (get (get this.weekdayTaxiVehicleTripCalcs time) inOutOrTotal.key)}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                      <td>
+                        -
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round (get (get weekdayVehicleTripTotals time) inOutOrTotal.key)}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                    {{else if (not-eq time "saturday")}}
+                      {{#each this.modalSplitVariablesSubset as |mode|}}
+                        <td>
+                          {{round (get (get this.totalsOfWeekdayMode time) mode)}}
+                        </td>
+                      {{/each}}
+                      <td>
+                        {{round (get this.totalsOfTotalsOfWeekdayMode time)}}
+                      </td>
+                      <td>
+                        {{round (get this.totalsOfWeekdayAutoVehicleTrip time)}}
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round (get this.totalsOfWeekdayTaxiVehicleTrip time)}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                      <td>
+                        -
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round (get this.totalsOfTotalsOfWeekdayVehicleTrip time)}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                    {{else if (not-eq inOutOrTotal.key "total")}}
+                      {{#each this.modalSplitVariablesSubset as |mode|}}
+                        <td>
+                          {{round (get (get this.saturdayModeCalcs inOutOrTotal.key) mode)}}
+                        </td>
+                      {{/each}}
+                      <td>
+                        {{round (get this.saturdayModesTotals inOutOrTotal.key)}}
+                      </td>
+                      <td>
+                        {{round (get this.saturdayAutoVehicleTripCalcs inOutOrTotal.key)}}
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round (get this.saturdayTaxiVehicleTripCalcs inOutOrTotal.key)}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                      <td>
+                        -
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round (get this.saturdayVehicleTripTotals inOutOrTotal.key)}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                    {{else}}
+                      {{#each this.modalSplitVariablesSubset as |mode|}}
+                        <td>
+                          {{round (get this.totalsOfSaturdayMode mode)}}
+                        </td>
+                      {{/each}}
+                      <td>
+                        {{round this.totalOfTotalsOfSaturdayMode}}
+                      </td>
+                      <td>
+                        {{round this.totalOfSaturdayAutoVehicleTrip}}
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round this.totalOfSaturdayTaxiVehicleTrip}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                      <td>
+                        -
+                      </td>
+                      <td>
+                        {{#if ta.taxiVehicleOccupancy}}
+                          {{round this.totalOfTotalsOfSaturdayVehicleTrip}}
+                        {{else}}
+                          -
+                        {{/if}}
+                      </td>
+                    {{/if}}
+                  {{/with}}
+                {{/with}}
+              {{/with}}
+            </tr>
+          {{/each}}
+        {{/each-in}}
+      {{/if}}
+    </tbody>
+  </table>
+</div>

--- a/frontend/app/templates/project/show.hbs
+++ b/frontend/app/templates/project/show.hbs
@@ -1,4 +1,4 @@
-{{title project.name separator=" " replace=true}}
+{{title this.model.project.name separator=" " replace=true}}
 
 <div class="row">
   <div class="sixteen wide column">

--- a/frontend/app/templates/project/show/transportation.hbs
+++ b/frontend/app/templates/project/show/transportation.hbs
@@ -1,9 +1,9 @@
 {{! Shares the controller context from 'project' }}
 {{title "[Transportation]" prepend=false}}
-{{#if showAnalysisSteps}}
+{{#if this.projectCtrl.showAnalysisSteps}}
   <div class="row">
     <div class="sixteen wide column">
-      <Transportation::AnalysisSteps @project={{project}} />
+      <Transportation::AnalysisSteps @project={{this.model.project}} />
     </div>
   </div>
 {{/if}}

--- a/frontend/app/templates/project/show/transportation/existing-conditions.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions.hbs
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::ExistingConditions::ExistingConditionsSteps
-      @project={{project}}
+      @project={{this.model.project}}
     />
   </div>
 </div>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/census-tracts/map.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/census-tracts/map.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::CensusTractsMap
-      @project={{this.project}}
+      @project={{this.model.project}}
     />
   </div>
 </div>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/census-tracts/table.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/census-tracts/table.hbs
@@ -1,7 +1,16 @@
 <div class="row">
   <div class="sixteen wide column">
+    <Transportation::DataSourceToggle
+      @switch={{this.isRJTW}}
+      @falseLabel="Journey To Work"
+      @trueLabel="Reverse Journey To Work"
+    />
     <Transportation::CensusTractsTable
-      @analysis={{model.transportationAnalysis}}
+      @isRJTW={{this.isRJTW}}
+      @selectedCensusTractIds={{this.selectedCensusTractIds}}
+      @selectedCensusTractData={{await this.selectedCensusTractData}}
+      @modeLookup={{this.modeLookup}}
+      @commuterModes={{this.commuterModes}}
     />
   </div>
 </div>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/map.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/map.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::TripGenerationMap
-      @project={{this.project}}
+      @project={{this.model.project}}
     />
   </div>
 </div>

--- a/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/table.hbs
+++ b/frontend/app/templates/project/show/transportation/existing-conditions/trip-generation/table.hbs
@@ -1,5 +1,37 @@
 <div class="row">
   <div class="sixteen wide column">
-    Trip Gen Table
+    <Transportation::DataSourceToggle
+      @switch={{this.isRJTW}}
+      @falseLabel="Residential"
+      @trueLabel="Offices"
+    />
+  </div>
+</div>
+<div class="row">
+  <div class="sixteen wide column">
+    <Transportation::TripGenerationTables::ModalSplitsVehicleOccupancy
+      @analysis={{this.model.transportationAnalysis}}
+      @selectedCensusTractData={{await this.selectedCensusTractData}}
+      @modeLookup={{this.modeLookup}}
+      @commuterModes={{this.commuterModes}}
+      @modalSplitVariablesSubset={{modalSplitVariablesSubset}}
+    />
+  </div>
+</div>
+<div class="row">
+  <div class="sixteen wide column">
+    <Transportation::TripGenerationTables::TripGenerationRates
+      @analysis={{this.model.transportationAnalysis}}
+    />
+  </div>
+</div>
+<div class="row">
+  <div class="sixteen wide column">
+    <Transportation::TripGenerationTables::TripGenerationResults
+      @analysis={{this.model.transportationAnalysis}}
+      @selectedCensusTractData={{await this.selectedCensusTractData}}
+      @modeLookup={{this.modeLookup}}
+      @modalSplitVariablesSubset={{modalSplitVariablesSubset}}
+    />
   </div>
 </div>

--- a/frontend/app/utils/modalSplit.js
+++ b/frontend/app/utils/modalSplit.js
@@ -91,6 +91,14 @@ export const AUTO_OCCUPANCY_RATES = {
   trans_auto_7_or_more: 7
 } 
 
+export const MODAL_SPLIT_VARIABLES_SUBSET = [
+  'trans_auto_total',
+  'trans_taxi',
+  'trans_public_bus',
+  'trans_public_subway',
+  'trans_walk'
+]
+
 /**
  * fetchAndSave function for readonly-ceqr-data-store fetch(); makes an
  * authenticated call to the rails backend to get estimates for a given geoid, 

--- a/frontend/mirage/factories/transportation-analysis.js
+++ b/frontend/mirage/factories/transportation-analysis.js
@@ -14,4 +14,27 @@ export default Factory.extend({
   project: association({
     totalUnits: 1000,
   }),
+  inOutDists: () => {
+    return {
+      am: {
+        in: 50,
+        out: 50
+      },
+      md: {
+        in: 50,
+        out: 50
+      },
+      pm: {
+        in: 50,
+        out: 50
+      },
+      saturday: {
+        in: 50,
+        out: 50
+      }
+    }
+  },
+  taxiVehicleOccupancy: () => {
+    return null;
+  }
 });

--- a/frontend/mirage/helpers/get-transportation-census-estimate-response.js
+++ b/frontend/mirage/helpers/get-transportation-census-estimate-response.js
@@ -7,7 +7,11 @@ export default function getTransportationCensusEstimateResponse(type) {
   return { data: [...attributes] };
 }
 
+// Ideally a unique geoid is passed in for each call to this function.
 function createTransportationCensusEstimates(type, geoid) {
+
+  const fakeGeoid = geoid ? geoid : `${(Math.random().toFixed(2)*100).toString().padEnd(11, '0')}`;
+
   const totalVariable = type === 'ACS' ? 'population' : 'workers';
   const variables = [
     totalVariable,
@@ -18,9 +22,9 @@ function createTransportationCensusEstimates(type, geoid) {
     ...AUTO_BREAKDOWN_VARIABLES
   ];
 
-  const censusEstimates = variables.map((variable, idx) => {
+  const censusEstimates = variables.map((variable) => {
     return {
-      geoid: geoid ? geoid : `${idx.toString().padEnd(11, '0')}`,
+      geoid: fakeGeoid,
       variable: variable,
       value: faker.random.number({min:10, max:1000}),
       moe: faker.random.number({min:1, max:20}),

--- a/frontend/tests/integration/components/transportation/census-tracts-table-test.js
+++ b/frontend/tests/integration/components/transportation/census-tracts-table-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, find, render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import stubReadonlyStore from '../../../helpers/stub-readonly-store';
@@ -11,97 +11,180 @@ module('Integration | Component | transportation/census-tracts-table', function(
   setupMirage(hooks);
   stubReadonlyStore(hooks);
 
-  test('it toggles between JTW and RJTW', async function(assert) {
-    // Set up table with simple data
-    const project = server.create('project');
-    this.model = await this.owner.lookup('service:store')
-      .findRecord('project', project.id, { include: 'transportation-analysis'});
+  hooks.beforeEach(async function() {
+    this.stubSelectedCensusTractIds = ['1', '2'];
+    this.stubSelectedCensusTractData = [
+      {
+        'trans_commuter_total': { 
+          geoid: 1,
+          variable: 'trans_commuter_total',
+          value: 10,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_commuter_total']
+        },
+        'trans_auto_total': { 
+          geoid: 1,
+          variable: 'trans_auto_total',
+          value: 1,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_auto_total']
+        },
+        'trans_taxi': { 
+          geoid: 1,
+          variable: 'trans_taxi',
+          value: 2,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_taxi']
+        },
+        'trans_public_bus': { 
+          geoid: 1,
+          variable: 'trans_public_bus',
+          value: 3,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_bus']
+        },
+        'trans_public_subway': { 
+          geoid: 1,
+          variable: 'trans_public_subway',
+          value: 4,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_subway']
+        },
+        'trans_walk': { 
+          geoid: 1,
+          variable: 'trans_walk',
+          value: 5,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_walk']
+        },
+        'vehicle_occupancy': { 
+          geoid: 1,
+          variable: 'vehicle_occupancy',
+          value: 6,
+          moe: null,
+          mode: VARIABLE_MODE_LOOKUP['vehicle_occupancy']
+        }
+      },
+      {
+        'trans_commuter_total': { 
+          geoid: 2,
+          variable: 'trans_commuter_total',
+          value: 20,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_commuter_total']
+        },
+        'trans_auto_total': { 
+          geoid: 2,
+          variable: 'trans_auto_total',
+          value: 21,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_auto_total']
+        },
+        'trans_taxi': { 
+          geoid: 2,
+          variable: 'trans_taxi',
+          value: 3,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_taxi']
+        },
+        'trans_public_bus': { 
+          geoid: 2,
+          variable: 'trans_public_bus',
+          value: 4,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_bus']
+        },
+        'trans_public_subway': { 
+          geoid: 2,
+          variable: 'trans_public_subway',
+          value: 5,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_subway']
+        },
+        'trans_walk': { 
+          geoid: 2,
+          variable: 'trans_walk',
+          value: 6,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_walk']
+        },
+        'vehicle_occupancy': { 
+          geoid: 2,
+          variable: 'vehicle_occupancy',
+          value: 7,
+          moe: null,
+          mode: VARIABLE_MODE_LOOKUP['vehicle_occupancy']
+        }
+      },
+    ];
+    this.modeLookup       = VARIABLE_MODE_LOOKUP;
+    this.commuterModes    = COMMUTER_VARIABLES;
+    this.isRJTW = false;
 
-    const requiredGeoids = ['3'];
-    this.model.set('transportationAnalysis.requiredJtwStudySelection', requiredGeoids);
+    await render(hbs`{{transportation/census-tracts-table
+      isRJTW=this.isRJTW
+      selectedCensusTractIds=this.stubSelectedCensusTractIds
+      selectedCensusTractData=this.stubSelectedCensusTractData
+      modeLookup=this.modeLookup
+      commuterModes=this.commuterModes
+    }}`);
 
-    await render(hbs`{{transportation/census-tracts-table analysis=model.transportationAnalysis}}`);
+  });
 
-    // get refs to Journey To Work and Reverse Journey To Work buttons.
-    let jtwButton  = find('[data-test-censustracts-table-isrjtw="false"]');
-    let rjtwButton = find('[data-test-censustracts-table-isrjtw="true"]');
-    
+  test('it toggles between JTW and RJTW labels', async function(assert) {
+
     // get ref to row displaying base unit values and percents
     let baseUnitModeRow = find('[data-test-censustracts-table-baseunit]');
 
     // Table is in JTW mode on load
-    assert.equal(jtwButton.classList.contains('active'), true);
-    assert.equal(rjtwButton.classList.contains('active'), false);
     assert.equal(baseUnitModeRow.querySelector('td:first-child').textContent.includes('Population'), true);
     assert.equal(baseUnitModeRow.querySelector('td:first-child').textContent.includes('Workers'), false);
 
+    this.set('isRJTW', true);
     // Table switches to RJTW mode after clicking RJTW button
-    await click("[data-test-censustracts-table-isrjtw='true']");
-
-    assert.equal(jtwButton.classList.contains('active'), false);
-    assert.equal(rjtwButton.classList.contains('active'), true);
     assert.equal(baseUnitModeRow.querySelector('td:first-child').textContent.includes('Population'), false);
     assert.equal(baseUnitModeRow.querySelector('td:first-child').textContent.includes('Workers'), true);
 
+    this.set('isRJTW', false);
     // Table switches back to JTW mode after clicking JTW button
-    await click("[data-test-censustracts-table-isrjtw='false']");
-
-    assert.equal(jtwButton.classList.contains('active'), true);
-    assert.equal(rjtwButton.classList.contains('active'), false);
     assert.equal(baseUnitModeRow.querySelector('td:first-child').textContent.includes('Population'), true);
     assert.equal(baseUnitModeRow.querySelector('td:first-child').textContent.includes('Workers'), false);
   });
 
   test('it displays a table with columns and subcolumns for all selected census tracts', async function(assert) {
-    // If a project exists with transportation analysis with jtwStudySelection and requiredJtwStudySelection
-    const project = server.create('project');
-    this.model = await this.owner.lookup('service:store')
-      .findRecord('project', project.id, { include: 'transportation-analysis'});
 
-    const selectedGeoids = ['1', '2'];
-    this.model.set('transportationAnalysis.jtwStudySelection', selectedGeoids);
-    const requiredGeoids = ['3', '4'];
-    this.model.set('transportationAnalysis.requiredJtwStudySelection', requiredGeoids);
-
-    // When the table is rendered with the transportation analysis
-    await render(hbs`{{transportation/census-tracts-table analysis=model.transportationAnalysis}}`);
-
-    // Then the table will have # of top level headers = # of required geoids + # of selected geoids + 2
+    // Table will have # of top level headers = # of required geoids + # of selected geoids + 2
     // (one for titles column, and one for 'Total' aggregate values column)
     let tableHead = find('thead');
-    assert.equal(tableHead.querySelectorAll(':scope > tr:first-child > th').length, selectedGeoids.length + requiredGeoids.length + 2);
+    assert.equal(tableHead.querySelectorAll(':scope > tr:first-child > th').length, this.stubSelectedCensusTractIds.length + 2);
 
     // and the table will have two subheaders for each census-tract column.
     // i.e. # of sub-headers equals # top level headers + (2 * (# required geoids + # selected geoidsd)) + 1 for title + 2 for total column)
-    assert.equal(tableHead.querySelectorAll(':scope > tr:nth-child(2) > th').length, 2 * (selectedGeoids.length + requiredGeoids.length) + 1 + 2);
+    assert.equal(tableHead.querySelectorAll(':scope > tr:nth-child(2) > th').length, 2 * this.stubSelectedCensusTractIds.length + 2);
 
   });
 
   test('it displays table with rows for transportation modes, each row displaying a count and a percent for each census tract column', async function(assert) {
-    // If a project exists with transportation analysis with requiredJtwStudySelection
-    const project = server.create('project');
-    this.model = await this.owner.lookup('service:store')
-      .findRecord('project', project.id, { include: 'transportation-analysis'});
-
-    const requiredGeoids = ['3'];
-    this.model.set('transportationAnalysis.requiredJtwStudySelection', requiredGeoids);
-
-    // When the table is rendered with the transportation analysis
-    await render(hbs`{{transportation/census-tracts-table analysis=model.transportationAnalysis}}`);
 
     const table = find('tbody');
 
     // Then the table will have rows for each transportation mode.
-    // Following mode-specific rows, the last four rows are Total, Total without work from home, Population/Worker, and Vehicle Occupancy.
-    assert.ok(table.rows.length == COMMUTER_VARIABLES.length + 4);
+    // Following mode-specific rows, there the last five rows are Total, Total without work from home, Population/Worker,
+    // a "header" row for Vehicle Occupancy, and Vehicle Occupancy.
+    assert.ok(table.rows.length == COMMUTER_VARIABLES.length + 1 + 4);
     
     for (let i = 0; i < table.rows.length; i++) {
-        const modeLabelCell = table.rows[i].cells[0];
-        // Each mode row has a title column with text corresponding to the respective human-readable mode label
-        if(i < table.rows.length - 4){
-          assert.ok(modeLabelCell.textContent.includes(VARIABLE_MODE_LOOKUP[COMMUTER_VARIABLES[i]]));
-        }
+      const modeLabelCell = table.rows[i].cells[0];
+      // Each mode row has a title column with text corresponding to the respective human-readable mode label
+      if(i < table.rows.length - 5){
+        assert.ok(modeLabelCell.textContent.includes(VARIABLE_MODE_LOOKUP[COMMUTER_VARIABLES[i]]));
+      }
 
+      // There should be a header row for Average Vehicle Occupancy
+      if(i == table.rows.length - 2){
+        assert.ok(table.rows[i].cells[1].textContent.includes('Average'));
+      } else {
+        // Except for the Average Vehicle Occupancy header row...
         // Each row will have pairs of columns for each census tract, one for Count and one for Percent.
         const modeCountCell = table.rows[i].cells[1];
         const countCellFormat = /\d+/;
@@ -111,6 +194,7 @@ module('Integration | Component | transportation/census-tracts-table', function(
         // Vehicle Occupancy row, the last row, has "-" for percent 
         const percentCellFormat = (i == table.rows.length - 1) ? /-/ : /\d+\.\d\s%/;
         assert.ok(modePercentCell.textContent.match(percentCellFormat));
+      }
     }
 
   });

--- a/frontend/tests/integration/components/transportation/census-tracts-table/value-and-percent-row-test.js
+++ b/frontend/tests/integration/components/transportation/census-tracts-table/value-and-percent-row-test.js
@@ -18,10 +18,13 @@ module('Integration | Component | transportation/census-tracts-table/value-and-p
     this.set('variables', ['trans_total']);
 
     // When component is rendered with title, modalSplits, and variables array
-    await render(hbs`{{transportation/census-tracts-table/value-and-percent-row title=title allModalSplitData=modalSplits variables=variables}}`);
+    await render(hbs`{{transportation/census-tracts-table/value-and-percent-row
+      title=title allModalSplitData=modalSplits
+      variables=variables
+    }}`);
 
     // Then it renders the title, variable count and percent, and total variable count and percent
     const row = find('tr');
-    assert.ok(row.textContent.match(/testTitle\s+\d+±\d+\s+\d+\.\d+\s%\s+\d+\s+\d+\.\d+\s%/));
+    assert.ok(row.textContent.match(/testTitle\s+\d+\s+\d+\.\d+\s%\s+\d+±\d+\s+\d+\.\d+\s%/));
   });
 });

--- a/frontend/tests/integration/components/transportation/data-source-toggle-test.js
+++ b/frontend/tests/integration/components/transportation/data-source-toggle-test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | transportation/data-source-toggle', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    this.isRJTW = false;
+    this.falseLabel = "Journey To Work";
+    this.trueLabel = "Journey To Work";
+
+    await render(hbs`{{transportation/data-source-toggle
+      switch=this.isRJTW
+      falseLabel=this.falseLabel
+      trueLabel=this.trueLabel
+    }}`);
+
+  })
+
+  test('it toggles the switch and indicates its state', async function(assert) {
+
+    // get refs to Journey To Work and Reverse Journey To Work buttons.
+    let jtwButton  = find('[data-test-censustracts-table-isrjtw="false"]');
+    let rjtwButton = find('[data-test-censustracts-table-isrjtw="true"]');
+
+    // Table is in JTW mode on load
+    assert.equal(jtwButton.classList.contains('active'), true);
+    assert.equal(rjtwButton.classList.contains('active'), false);
+
+    // Table switches to RJTW mode after clicking RJTW button
+    await click("[data-test-censustracts-table-isrjtw='true']");
+
+    assert.equal(jtwButton.classList.contains('active'), false);
+    assert.equal(rjtwButton.classList.contains('active'), true);
+
+    // Table switches back to JTW mode after clicking JTW button
+    await click("[data-test-censustracts-table-isrjtw='false']");
+
+    assert.equal(jtwButton.classList.contains('active'), true);
+    assert.equal(rjtwButton.classList.contains('active'), false);
+
+
+  })
+
+});

--- a/frontend/tests/integration/components/transportation/trip-generation-tables/modal-splits-vehicle-occupancy-test.js
+++ b/frontend/tests/integration/components/transportation/trip-generation-tables/modal-splits-vehicle-occupancy-test.js
@@ -1,0 +1,11 @@
+// TODO: Write UI tests for this table after design is approved.
+
+// import { module, test } from 'qunit';
+// import { setupRenderingTest } from 'ember-qunit';
+// import { render } from '@ember/test-helpers';
+// import hbs from 'htmlbars-inline-precompile';
+
+// module('Integration | Component | transportation/trip-generation-tables/modal-splits-vehicle-occupancy', function(hooks) {
+//   setupRenderingTest(hooks);
+
+// });

--- a/frontend/tests/integration/components/transportation/trip-generation-tables/trip-generation-rates-test.js
+++ b/frontend/tests/integration/components/transportation/trip-generation-tables/trip-generation-rates-test.js
@@ -1,0 +1,10 @@
+// TODO: write UI tests for this table after design is approved..
+// import { module, test } from 'qunit';
+// import { setupRenderingTest } from 'ember-qunit';
+// import { render } from '@ember/test-helpers';
+// import hbs from 'htmlbars-inline-precompile';
+
+// module('Integration | Component | transportation/trip-generation-tables/trip-generation-rates', function(hooks) {
+//   setupRenderingTest(hooks);
+
+// });

--- a/frontend/tests/integration/components/transportation/trip-generation-tables/trip-generation-results-test.js
+++ b/frontend/tests/integration/components/transportation/trip-generation-tables/trip-generation-results-test.js
@@ -1,0 +1,10 @@
+// TODO: write UI tests for this table after design is approved.
+// import { module, test } from 'qunit';
+// import { setupRenderingTest } from 'ember-qunit';
+// import { render } from '@ember/test-helpers';
+// import hbs from 'htmlbars-inline-precompile';
+
+// module('Integration | Component | transportation/trip-generation-tables/trip-generation-results', function(hooks) {
+//   setupRenderingTest(hooks);
+
+// });

--- a/frontend/tests/unit/components/transportation/trip-generation-tables/trip-generation-results-test.js
+++ b/frontend/tests/unit/components/transportation/trip-generation-tables/trip-generation-results-test.js
@@ -1,0 +1,320 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { getAggregatePercent } from 'labs-ceqr/helpers/get-aggregate-percent';
+import { MODAL_SPLIT_VARIABLES_SUBSET, VARIABLE_MODE_LOOKUP } from 'labs-ceqr/utils/modalSplit';
+
+module('Unit | Component | transportation/trip-generation-tables/trip-generation-results', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+
+    this.stubAnalysis = {
+      taxiVehicleOccupancy: 2,
+      residentialUnits: 500,
+      inOutDists: {
+        am: {
+          in: 51,
+          out: 49
+        },
+        md: {
+          in: 62,
+          out: 38
+        },
+        pm: {
+          in: 34,
+          out: 66
+        },
+        saturday: {
+          in: 56,
+          out: 44
+        }
+      },
+      dailyTripRate: {
+        weekday:  {label: "Weekday", rate:  8.075},
+        saturday: {label: "Saturday", rate: 9.6}
+      },
+      temporalDistributions: {
+        am:       {label: "AM",       percent: 10, decimal: .10 },
+        md:       {label: "MD",       percent: 5,  decimal: .05 },
+        pm:       {label: "PM",       percent: 11, decimal: .11 },
+        saturday: {label: "Saturday", percent: 8,  decimal: .08 }
+      },
+    };
+    this.stubSelectedCensusTractData = [
+      {
+        'trans_commuter_total': { 
+          variable: 'trans_commuter_total',
+          value: 10,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_commuter_total']
+        },
+        'trans_auto_total': { 
+          variable: 'trans_auto_total',
+          value: 1,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_auto_total']
+        },
+        'trans_taxi': { 
+          variable: 'trans_taxi',
+          value: 2,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_taxi']
+        },
+        'trans_public_bus': { 
+          variable: 'trans_public_bus',
+          value: 3,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_bus']
+        },
+        'trans_public_subway': { 
+          variable: 'trans_public_subway',
+          value: 4,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_subway']
+        },
+        'trans_walk': { 
+          variable: 'trans_walk',
+          value: 5,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_walk']
+        },
+        'vehicle_occupancy': { 
+          variable: 'vehicle_occupancy',
+          value: 6,
+          moe: null,
+          mode: VARIABLE_MODE_LOOKUP['vehicle_occupancy']
+        }
+      },
+      {
+        'trans_commuter_total': { 
+          variable: 'trans_commuter_total',
+          value: 20,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_commuter_total']
+        },
+        'trans_auto_total': { 
+          variable: 'trans_auto_total',
+          value: 21,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_auto_total']
+        },
+        'trans_taxi': { 
+          variable: 'trans_taxi',
+          value: 3,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_taxi']
+        },
+        'trans_public_bus': { 
+          variable: 'trans_public_bus',
+          value: 4,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_bus']
+        },
+        'trans_public_subway': { 
+          variable: 'trans_public_subway',
+          value: 5,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_public_subway']
+        },
+        'trans_walk': { 
+          variable: 'trans_walk',
+          value: 6,
+          moe: 1,
+          mode: VARIABLE_MODE_LOOKUP['trans_walk']
+        },
+        'vehicle_occupancy': { 
+          variable: 'vehicle_occupancy',
+          value: 7,
+          moe: null,
+          mode: VARIABLE_MODE_LOOKUP['vehicle_occupancy']
+        }
+      },
+    ];
+    this.modeLookup                   = VARIABLE_MODE_LOOKUP;
+    this.modalSplitVariablesSubset    = MODAL_SPLIT_VARIABLES_SUBSET;
+
+    this.tripGenResultsTable =  this.owner.lookup('component:transportation/trip-generation-tables/trip-generation-results');
+    this.tripGenResultsTable.set('analysis', this.stubAnalysis);
+    this.tripGenResultsTable.set('selectedCensusTractData', this.stubSelectedCensusTractData);
+    this.tripGenResultsTable.set('modeLookup', this.modeLookup);
+    this.tripGenResultsTable.set('modalSplitVariablesSubset', this.modalSplitVariablesSubset);
+  });
+
+  test('it correctly calculates modeAggregatePercents', async function(assert) {
+    assert.deepEqual(this.tripGenResultsTable.modeAggregatePercents, {
+      'trans_auto_total':    getAggregatePercent([this.stubSelectedCensusTractData, ['trans_auto_total'], false]) / 100,
+      'trans_taxi':          getAggregatePercent([this.stubSelectedCensusTractData, ['trans_taxi'], false]) / 100,
+      'trans_public_bus':    getAggregatePercent([this.stubSelectedCensusTractData, ['trans_public_bus'], false]) / 100,
+      'trans_public_subway': getAggregatePercent([this.stubSelectedCensusTractData, ['trans_public_subway'], false]) / 100,
+      'trans_walk':          getAggregatePercent([this.stubSelectedCensusTractData, ['trans_walk'], false]) / 100,
+    });
+  });
+
+  test('it spot checks weekdayModeCalcs for public-bus/midday/out-direction', async function(assert) {
+      assert.equal(this.tripGenResultsTable.weekdayModeCalcs.md.out.trans_public_bus, 
+      this.stubAnalysis.residentialUnits *
+      this.stubAnalysis.dailyTripRate.weekday.rate *
+      this.stubAnalysis.temporalDistributions.md.decimal *
+      (this.stubAnalysis.inOutDists.md.out / 100) *
+      this.tripGenResultsTable.modeAggregatePercents['trans_public_bus']  
+    );
+  });
+
+  test('it spot checks weekdayModesTotals for pm/in', async function(assert) {
+    assert.equal(this.tripGenResultsTable.weekdayModesTotals.pm.in,
+      this.tripGenResultsTable.weekdayModeCalcs.pm.in.trans_auto_total +
+      this.tripGenResultsTable.weekdayModeCalcs.pm.in.trans_taxi +
+      this.tripGenResultsTable.weekdayModeCalcs.pm.in.trans_public_bus +
+      this.tripGenResultsTable.weekdayModeCalcs.pm.in.trans_public_subway + 
+      this.tripGenResultsTable.weekdayModeCalcs.pm.in.trans_walk
+    );
+  });
+
+  test('it spot checks totalsOfWeekdayMode for am/trans_walk', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfWeekdayMode.am.trans_walk,
+      this.tripGenResultsTable.weekdayModeCalcs.am.in.trans_walk +
+      this.tripGenResultsTable.weekdayModeCalcs.am.out.trans_walk
+    );
+  });
+
+  test('it spot checks totalsOfTotalsOfWeekdayMode for md', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfTotalsOfWeekdayMode.am,
+      this.tripGenResultsTable.totalsOfWeekdayMode.am.trans_auto_total +
+      this.tripGenResultsTable.totalsOfWeekdayMode.am.trans_taxi +
+      this.tripGenResultsTable.totalsOfWeekdayMode.am.trans_public_bus +
+      this.tripGenResultsTable.totalsOfWeekdayMode.am.trans_public_subway + 
+      this.tripGenResultsTable.totalsOfWeekdayMode.am.trans_walk
+    );
+  });
+
+  test('it spot checks saturdayModeCalcs for out/trans_auto_total', async function(assert) {
+    assert.equal(this.tripGenResultsTable.saturdayModeCalcs.out.trans_auto_total,
+      this.stubAnalysis.residentialUnits *
+      this.stubAnalysis.dailyTripRate.saturday.rate *
+      this.stubAnalysis.temporalDistributions.saturday.decimal *
+      (this.stubAnalysis.inOutDists.saturday.out / 100) *
+      this.tripGenResultsTable.modeAggregatePercents['trans_auto_total']  
+    );
+  });
+
+  test('it spot checks saturdayModesTotals for in direction', async function(assert) {
+    assert.equal(this.tripGenResultsTable.saturdayModesTotals.in,
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_auto_total +
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_taxi +
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_public_bus +
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_public_subway + 
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_walk
+    );
+  });
+
+  test('it spot checks totalsOfSaturdayMode for trans_taxi', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfSaturdayMode.trans_taxi,
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_taxi +
+      this.tripGenResultsTable.saturdayModeCalcs.out.trans_taxi
+    );
+  });
+
+  test('it calculates totalOfTotalsOfSaturdayMode', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalOfTotalsOfSaturdayMode,
+      this.tripGenResultsTable.totalsOfSaturdayMode.trans_auto_total +
+      this.tripGenResultsTable.totalsOfSaturdayMode.trans_taxi +
+      this.tripGenResultsTable.totalsOfSaturdayMode.trans_public_bus +
+      this.tripGenResultsTable.totalsOfSaturdayMode.trans_public_subway + 
+      this.tripGenResultsTable.totalsOfSaturdayMode.trans_walk
+    );
+  });
+
+  test('it correctly calculates vehicle occupancy', async function(assert) {
+    assert.equal(this.tripGenResultsTable.vehicleOccupancy, (6+7)/2);
+  });
+
+  test('it spot checks weekdayAutoVehicleTripCalcs for md/out', async function(assert) {
+    assert.equal(this.tripGenResultsTable.weekdayAutoVehicleTripCalcs.md.out, 
+      this.tripGenResultsTable.weekdayModeCalcs.md.out.trans_auto_total / this.tripGenResultsTable.vehicleOccupancy
+    );
+  });
+
+  test('it spot checks weekdayTaxiVehicleTripCalcs for am/in', async function(assert) {
+    assert.equal(this.tripGenResultsTable.weekdayTaxiVehicleTripCalcs.am.in, 
+      this.tripGenResultsTable.weekdayModeCalcs.am.in.trans_taxi / this.stubAnalysis.taxiVehicleOccupancy
+    );
+  });
+
+  test('it spot checks weekdayVehicleTripTotals for pm/out', async function(assert) {
+    assert.equal(this.tripGenResultsTable.weekdayVehicleTripTotals.pm.out, 
+      this.tripGenResultsTable.weekdayAutoVehicleTripCalcs.pm.out +
+      this.tripGenResultsTable.weekdayTaxiVehicleTripCalcs.pm.out
+    );
+  });
+
+  test('it spot checks totalsOfWeekdayAutoVehicleTrip for md', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfWeekdayAutoVehicleTrip.md, 
+      this.tripGenResultsTable.weekdayAutoVehicleTripCalcs.md.in +
+      this.tripGenResultsTable.weekdayAutoVehicleTripCalcs.md.out
+    );
+  });
+
+  test('it spot checks totalsOfWeekdayTaxiVehicleTrip for pm', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfWeekdayTaxiVehicleTrip.pm, 
+      this.tripGenResultsTable.weekdayTaxiVehicleTripCalcs.pm.in +
+      this.tripGenResultsTable.weekdayTaxiVehicleTripCalcs.pm.out
+    );
+  });
+
+  test('it spot checks totalsOfTotalsOfWeekdayVehicleTrip for am', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfTotalsOfWeekdayVehicleTrip.am, 
+      this.tripGenResultsTable.totalsOfWeekdayAutoVehicleTrip.am +
+      this.tripGenResultsTable.totalsOfWeekdayTaxiVehicleTrip.am
+    );
+  });
+
+  test('it spot checks totalsOfTotalsOfWeekdayVehicleTrip for am', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalsOfTotalsOfWeekdayVehicleTrip.am, 
+      this.tripGenResultsTable.totalsOfWeekdayAutoVehicleTrip.am +
+      this.tripGenResultsTable.totalsOfWeekdayTaxiVehicleTrip.am
+    );
+  });
+
+  test('it spot checks saturdayAutoVehicleTripCalcs for in', async function(assert) {
+    assert.equal(this.tripGenResultsTable.saturdayAutoVehicleTripCalcs.in, 
+      this.tripGenResultsTable.saturdayModeCalcs.in.trans_auto_total / this.tripGenResultsTable.vehicleOccupancy
+    );
+  });
+
+  test('it spot checks saturdayTaxiVehicleTripCalcs for out', async function(assert) {
+    assert.equal(this.tripGenResultsTable.saturdayTaxiVehicleTripCalcs.out, 
+      this.tripGenResultsTable.saturdayModeCalcs.out.trans_taxi / this.stubAnalysis.taxiVehicleOccupancy
+    );
+  });
+
+  test('it spot checks saturdayVehicleTripTotals for in', async function(assert) {
+    assert.equal(this.tripGenResultsTable.saturdayVehicleTripTotals.in, 
+      this.tripGenResultsTable.saturdayAutoVehicleTripCalcs.in +
+      this.tripGenResultsTable.saturdayTaxiVehicleTripCalcs.in
+    );
+  });
+
+  test('it spot checks totalOfSaturdayAutoVehicleTrip', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalOfSaturdayAutoVehicleTrip, 
+      this.tripGenResultsTable.saturdayAutoVehicleTripCalcs.in +
+      this.tripGenResultsTable.saturdayAutoVehicleTripCalcs.out
+    );
+  });
+
+  test('it spot checks totalOfSaturdayTaxiVehicleTrip', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalOfSaturdayTaxiVehicleTrip, 
+      this.tripGenResultsTable.saturdayTaxiVehicleTripCalcs.in +
+      this.tripGenResultsTable.saturdayTaxiVehicleTripCalcs.out
+    );
+  });
+
+  test('it spot checks totalOfTotalsOfSaturdayVehicleTrip', async function(assert) {
+    assert.equal(this.tripGenResultsTable.totalOfTotalsOfSaturdayVehicleTrip, 
+      this.tripGenResultsTable.totalOfSaturdayAutoVehicleTrip +
+      this.tripGenResultsTable.totalOfSaturdayTaxiVehicleTrip
+    );
+  });
+
+});

--- a/frontend/tests/unit/controllers/project/show/transportation/existing-conditions-test.js
+++ b/frontend/tests/unit/controllers/project/show/transportation/existing-conditions-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | project/show/transportation/existing-conditions', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:project/show/transportation/existing-conditions');
+    assert.ok(controller);
+  });
+});

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/census-tracts-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/census-tracts-test.js
@@ -9,8 +9,4 @@ module('Unit | Route | project/show/transportation/existing-conditions/census-tr
     assert.ok(route);
   });
 
-  test('it is bound to the project controller', function(assert) {
-    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/census-tracts');
-    assert.equal(route.controllerName, 'project');
-  });
 });

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/journey-to-work-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/journey-to-work-test.js
@@ -9,9 +9,4 @@ module('Unit | Route | project/show/transportation/existing-conditions/journey-t
     assert.ok(route);
   });
 
-  test('it is bound to the project controller', function(assert) {
-    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/journey-to-work');
-    assert.equal(route.controllerName, 'project');
-  });
-
 });

--- a/frontend/tests/unit/routes/project/show/transportation/existing-conditions/trip-generation-test.js
+++ b/frontend/tests/unit/routes/project/show/transportation/existing-conditions/trip-generation-test.js
@@ -9,8 +9,4 @@ module('Unit | Route | project/show/transportation/existing-conditions/trip-gene
     assert.ok(route);
   });
 
-  test('it is bound to the project controller', function(assert) {
-    let route = this.owner.lookup('route:project/show/transportation/existing-conditions/trip-generation');
-    assert.equal(route.controllerName, 'project');
-  });
 });


### PR DESCRIPTION
## What

This PR mainly hooks up the rails backend to CTPP data. 
It also has two small frontend fixes to handle undefined modalSplit variables. 

In another PR, I need to make sure there is thorough and cohesive frontend handling of missing variables.

## Questions

It seems some of the CTPP census tracts are missing some variables. We should consider if cross-tract calculations are completely invalidated if one or more tracts are missing a variable, or if the calculations simply skip over those tracts. @pichot 


## Notes
This branch builds off of the branch in PR #421 , so that PR should be merged first. 