### PR TITLE
Fix JTW study area selections to be correct postgres array type

### DIFF
--- a/backend/db/migrate/20190610181704_add_required_jtw_study_selection_to_transportation_analysis.rb
+++ b/backend/db/migrate/20190610181704_add_required_jtw_study_selection_to_transportation_analysis.rb
@@ -1,6 +1,6 @@
 class AddRequiredJtwStudySelectionToTransportationAnalysis < ActiveRecord::Migration[5.2]
   def change
-    add_column :transportation_analyses, :required_jtw_study_selection, 'varchar(11)', default: [], array: true
+    add_column :transportation_analyses, :required_jtw_study_selection, :text, array: true, default: []
     TransportationAnalysis.all.each do |a|
       a.send(:compute_required_study_selection)
       a.save!
@@ -9,6 +9,6 @@ class AddRequiredJtwStudySelectionToTransportationAnalysis < ActiveRecord::Migra
 
     # also, recreate the jtw_study_selection column as varchar(11)[] type
     remove_column :transportation_analyses, :jtw_study_selection
-    add_column :transportation_analyses, :jtw_study_selection, 'varchar(11)', default: [], array: true
+    add_column :transportation_analyses, :jtw_study_selection, :text, array: true, default: []
   end
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -94,8 +94,8 @@ ActiveRecord::Schema.define(version: 2019_07_23_155612) do
     t.datetime "updated_at", null: false
     t.integer "project_id"
     t.geometry "jtw_study_area_centroid", limit: {:srid=>4326, :type=>"st_point"}, null: false
-    t.string "required_jtw_study_selection", limit: 11, default: [], null: false, array: true
-    t.string "jtw_study_selection", limit: 11, default: [], array: true
+    t.text "required_jtw_study_selection", default: [], null: false, array: true
+    t.text "jtw_study_selection", default: [], array: true
     t.jsonb "in_out_dists", default: {"am"=>{"in"=>50, "out"=>50}, "md"=>{"in"=>50, "out"=>50}, "pm"=>{"in"=>50, "out"=>50}, "saturday"=>{"in"=>50, "out"=>50}}
     t.float "taxi_vehicle_occupancy"
   end


### PR DESCRIPTION
Column type was set to `varchar(11)`, which quickly did not have enough space to store production data. To set a Postgres array type in a rails migration, use `:text` datatype, not `varchar`.