### PR TITLE
423  restore height to public schools study-area-map

### DIFF
--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -80,6 +80,9 @@ footer {
   vertical-align: inherit; 
 }
 
+//public schools
+#study-area-map,
+// transportation 
 #census-tracts-map, #trip-generation-map, #jtw-map {
   height: 550px;
 }

--- a/frontend/app/templates/components/transportation/existing-conditions/existing-conditions-steps.hbs
+++ b/frontend/app/templates/components/transportation/existing-conditions/existing-conditions-steps.hbs
@@ -13,11 +13,4 @@
   }}
     Trip Generation
   {{/link-to}}
-  {{#link-to
-    "project.show.transportation.existing-conditions.journey-to-work"
-    project.id
-    class="item"
-  }}
-    Journey to Work 
-  {{/link-to}}
 </div>


### PR DESCRIPTION
I accidentally deleted `#study-area-map` id select from the stylesheet, so adding it back in.

Rider: Also disabling the the "Trip Assignment" step button in the transportation analysis stepper.