### PR TITLE
ensure model is loaded in analysis-threshold route

### DIFF
--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -69,7 +69,7 @@ Router.map(function() {
       });
 
       this.route('transportation', function() {
-        this.route('analysis-threshold', {path: '/'});
+        this.route('analysis-threshold');
         this.route('existing-conditions', function() {
           this.route('census-tracts');
           this.route('journey-to-work');

--- a/frontend/app/routes/project/show/transportation.js
+++ b/frontend/app/routes/project/show/transportation.js
@@ -2,6 +2,10 @@ import Route from '@ember/routing/route';
 
 export default class ProjectShowTransportationRoute extends Route {
 
+  redirect(model) {
+    this.transitionTo('project.show.transportation.analysis-threshold', model);
+  }
+
   async setupController(controller) {
     const { project } = this.modelFor('project/show');
     const transportationAnalysis = await project.get('transportationAnalysis');

--- a/frontend/app/routes/project/show/transportation/analysis-threshold.js
+++ b/frontend/app/routes/project/show/transportation/analysis-threshold.js
@@ -2,4 +2,12 @@ import Route from '@ember/routing/route';
 
 export default class ProjectShowTransportationAnalysisThresholdRoute extends Route {
 
+  async setupController(controller) {
+    const { project } = this.modelFor('project/show');
+    const transportationAnalysis = await project.get('transportationAnalysis');
+
+    controller.set('model', { project, transportationAnalysis });
+    controller.set('projectCtrl', this.controllerFor('project'));
+  }
+
 }

--- a/frontend/app/templates/project/show/transportation/analysis-threshold.hbs
+++ b/frontend/app/templates/project/show/transportation/analysis-threshold.hbs
@@ -29,7 +29,7 @@
 <div class="row">
   <div class="sixteen wide column">
     <Transportation::TrafficZoneThresholds
-      @analysis={{model.transportationAnalysis}}
+      @analysis={{this.model.transportationAnalysis}}
       @project={{model.project}}
      />
 


### PR DESCRIPTION
Makes sure that the `transportationAnalysis` is loaded into the `analysis-threshold` route model and passed into the analysisThreshold component.

### Rider: 
Makes the `analysis-threshold` step explicit in the url. 
This also removes `analysis-threshold` route's hidden reliance on the parent `project/show/transportation` route for the model. 

### Todo: 
- Tests? I'm not sure how to test a model loads for a route, since usually the model is stubbed. @allthesignals thoughts?
