### PR TITLE
512: add intro text for transportation planning factors

### DIFF
--- a/frontend/app/templates/project/show/transportation/tdf/planning-factors.hbs
+++ b/frontend/app/templates/project/show/transportation/tdf/planning-factors.hbs
@@ -1,6 +1,24 @@
+<div class="sixteen wide column">
+  <div class="ui icon message">
+    <i class="attention icon"></i>
+    <div class="content">
+      <div class="header">
+        Explore Census Data for Residential and Office Land Uses
+      </div>
+      <p>
+        The CEQR Transportation chapter offers a census data explorer allowing you to select
+      census tracts for your project and gather mode split data from ACS and CTPP data sources.
+      </p>
+      <p>
+        <font color="red">We currently only offer data for Residential and Office land uses.</font>
+      </p>
+    </div>
+  </div>
+</div>
+
 <div class="row">
   <div class="sixteen wide column">
-    <Transportation::LandUseMenu 
+    <Transportation::LandUseMenu
       @tdfSection="planning-factors"
       @factors={{model.transportationPlanningFactors}}
     />


### PR DESCRIPTION
Add intro text to transportation chapter Planning Factors section. This text might change overtime but this is a placeholder for now. 

<img width="1357" alt="Screen Shot 2019-12-23 at 3 30 31 PM" src="https://user-images.githubusercontent.com/26672885/71379535-ab287200-2599-11ea-91c2-62e71762e2ab.png">

Closes #512 