### PR TITLE
Set up acceptance testing for transportation planning factors

### DIFF
--- a/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map/study-selection-toggler.js
+++ b/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map/study-selection-toggler.js
@@ -28,7 +28,7 @@ export default class TransportationCensusTractsMapStudySelectionTogglerComponent
 
   /**
    * Method to handle feature selection; adds a selected feature geoid to the analysis'
-   * jtwStudySelection array, or removes it if it already exists, and saves the analysis model
+   * censusTractsSelection array, or removes it if it already exists, and saves the analysis model
    * back to the server
    */
   async toggleCensusTract(selectedCensusTractFeatureArray) {    

--- a/frontend/app/models/data-package.js
+++ b/frontend/app/models/data-package.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 const { Model } = DS;
-import { attr } from '@ember-decorators/data';
+import { attr, hasMany } from '@ember-decorators/data';
 
 export default class DataPackageModel extends Model {
   @attr('string') name;
@@ -8,4 +8,7 @@ export default class DataPackageModel extends Model {
   @attr('string') version;
   @attr('date') releaseDate;
   @attr('') schemas;
+
+  @hasMany('project') projects;
+  @hasMany('transportationPlanningFactor') transportationPlanningFactors;
 }

--- a/frontend/app/models/transportation-planning-factor.js
+++ b/frontend/app/models/transportation-planning-factor.js
@@ -11,65 +11,73 @@ import EmberObject from '@ember/object';
 export default class TransportationPlanningFactorModel extends Model {
 
   
-  // Set defaults on values not received from server
-  ready() {
-    // Default inOutSplits
-    if (Object.keys(this.inOutSplits).length === 0) {
-      this.set('inOutSplits', {
-        am:       { in: 50, out: 50 },
-        md:       { in: 50, out: 50 },
-        pm:       { in: 50, out: 50 },
-        saturday: { in: 50, out: 50 }
-      });
-    }
-
-    // Default truckInOutSplits
-    if (Object.keys(this.truckInOutSplits).length === 0) {
-      this.set('truckInOutSplits', {
-        allDay:  { in: 50, out: 50 }
-      });
-    }
-
-    // Default modeSplits
-    if (Object.keys(this.modeSplitsFromUser).length === 0) {
-      const modeSplitsFromUser = {};
-      MODES.forEach((m) => modeSplitsFromUser[m] = { 
-        am:         0,
-        md:         0,
-        pm:         0,
-        saturday:   0,
-        allPeriods: 0
-      });
-      
-      this.set('modeSplitsFromUser', EmberObject.create(modeSplitsFromUser));
-    }
-
-    // Default truckInOutSplits
-    if (Object.keys(this.vehicleOccupancyFromUser).length === 0) {
-      this.set('vehicleOccupancyFromUser', {
-        auto: { 
-          am:         1,
-          md:         1,
-          pm:         1,
-          saturday:   1,
-          allPeriods: 1 
-        },
-        taxi: { 
-          am:         1,
-          md:         1,
-          pm:         1,
-          saturday:   1,
-          allPeriods: 1 
-        }
-      });
-    }
-  }
+    // Set defaults on values not received from server.
+    // For any property set through the ready() hook,
+    // if using Object.keys() to check if it is undefined,
+    // then make sure to set the defaultValue of the property to an empty object.
+    // This assumes that/follows the lead of the server in returning an empty object by default
+    // (instead of undefined) for those properties.
+    // TODO: refactor so that the 
+    ready() {
+      // Default inOutSplits
+      if (Object.keys(this.inOutSplits).length === 0) {
+        this.set('inOutSplits', {
+          am:       { in: 50, out: 50 },
+          md:       { in: 50, out: 50 },
+          pm:       { in: 50, out: 50 },
+          saturday: { in: 50, out: 50 }
+        });
+      }
   
+      // Default truckInOutSplits
+      if (Object.keys(this.truckInOutSplits).length === 0) {
+        this.set('truckInOutSplits', {
+          allDay:  { in: 50, out: 50 }
+        });
+      }
+      
+      // Default modeSplits
+      if (Object.keys(this.modeSplitsFromUser).length === 0) {
+        const modeSplitsFromUser = {};
+        MODES.forEach((m) => modeSplitsFromUser[m] = { 
+          am:         0,
+          md:         0,
+          pm:         0,
+          saturday:   0,
+          allPeriods: 0
+        });
+        
+        this.set('modeSplitsFromUser', EmberObject.create(modeSplitsFromUser));
+      }
+  
+      // Default truckInOutSplits
+      if (Object.keys(this.vehicleOccupancyFromUser).length === 0) {
+        this.set('vehicleOccupancyFromUser', {
+          auto: { 
+            am:         1,
+            md:         1,
+            pm:         1,
+            saturday:   1,
+            allPeriods: 1 
+          },
+          taxi: {
+            am:         1,
+            md:         1,
+            pm:         1,
+            saturday:   1,
+            allPeriods: 1 
+          }
+        });
+      }
+    }
+
   @belongsTo transportationAnalysis;
   @belongsTo dataPackage;
   
   @attr('string') landUse;
-  @attr({defaultValue: () => {}}) tableNotes;
+  @attr({
+    defaultValue: () => {return {}}
+  }) tableNotes;
   
   // Census tract variable data if landUse is residential or office
   @attr({defaultValue: () => []}) censusTractVariables;
@@ -84,7 +92,11 @@ export default class TransportationPlanningFactorModel extends Model {
   @attr('boolean') manualModeSplits;
   @attr('boolean') temporalModeSplits;
   @attr('boolean') temporalVehicleOccupancy;
-  @attr('ember-object', {defaultValue: () => {} }) modeSplitsFromUser;
+  @attr('ember-object', {
+    defaultValue: () => {
+      return {};
+    }
+  }) modeSplitsFromUser;
   
   @computed('manualModeSplits', 'censusTractsCalculator', 'modeSplitsFromUser')
   get modeSplits() {
@@ -99,7 +111,11 @@ export default class TransportationPlanningFactorModel extends Model {
   }
 
   // User-entered vehicle occupancy rate for "trip generation" existing conditions step
-  @attr({defaultValue: () => {}}) vehicleOccupancyFromUser;
+  @attr({
+    defaultValue: () => {
+      return {};
+    }
+  }) vehicleOccupancyFromUser;
   @computed('manualModeSplits', 'vehicleOccupancyFromUser', 'censusTractsCalculator')
   get vehicleOccupancy() {
     return this.vehicleOccupancyFromUser;
@@ -109,8 +125,13 @@ export default class TransportationPlanningFactorModel extends Model {
   }
 
   // The percentage values for trip generation per-peak-hour In and Out trip distributions
-  @attr({defaultValue: () => {}}) inOutSplits;
-  @attr({defaultValue: () => {}}) truckInOutSplits;
+  @attr({ defaultValue: () => {
+    return {}
+    }
+  }) inOutSplits;
+  @attr({defaultValue: () => {
+    return {};
+  }}) truckInOutSplits;
 
   @computed('transportationAnalysis.project.{totalUnits,commercialLandUse}', 'landUse')
   get units() {

--- a/frontend/app/routes/project/show.js
+++ b/frontend/app/routes/project/show.js
@@ -8,9 +8,11 @@ export default Route.extend({
     const project = await this.get('store').findRecord(
       'project',
       params.id,
-      { include: [
+      {
+        include: [
           'public-schools-analysis',
           'transportation-analysis',
+          'transportation-analysis.transportation-planning-factors',
           'community-facilities-analysis',
           'air-quality-analysis',
           'data-package'

--- a/frontend/app/routes/project/show/index.js
+++ b/frontend/app/routes/project/show/index.js
@@ -1,5 +1,11 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  controllerName: 'project'
+  controllerName: 'project',
+
+  actions: {
+    error(error) {
+      console.log("error from project/show/index: ", error); // eslint-disable-line
+    }
+  }
 });

--- a/frontend/app/routes/project/show/transportation.js
+++ b/frontend/app/routes/project/show/transportation.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { action } from '@ember-decorators/object';
 
 export default class ProjectShowTransportationRoute extends Route {
   controllerName = 'project';
@@ -11,5 +12,10 @@ export default class ProjectShowTransportationRoute extends Route {
       project,
       transportationAnalysis
     });
+  }
+
+  @action
+  error(error) {
+    console.log("error from project/show/transportation: ", error); // eslint-disable-line
   }
 }

--- a/frontend/app/routes/project/show/transportation/tdf/planning-factors.js
+++ b/frontend/app/routes/project/show/transportation/tdf/planning-factors.js
@@ -1,11 +1,11 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { action } from '@ember-decorators/object';
 
 export default class ProjectShowTransportationTdfPlanningFactorsRoute extends Route {
   async model() {
     const { project, transportationAnalysis } = this.modelFor('project/show');
-    const transportationPlanningFactors = await transportationAnalysis.transportationPlanningFactors;
-
+    const transportationPlanningFactors = await transportationAnalysis.get('transportationPlanningFactors');
     return RSVP.hash({
       project,
       transportationAnalysis,
@@ -20,5 +20,10 @@ export default class ProjectShowTransportationTdfPlanningFactorsRoute extends Ro
 
       this.replaceWith('project.show.transportation.tdf.planning-factors.show', project.id, factor.id);
     }
+  }
+
+  @action
+  error(error) {
+    console.log("error from project/show/transportation/tdf/planning-factors: ", error); // eslint-disable-line
   }
 }

--- a/frontend/app/routes/project/show/transportation/tdf/planning-factors/show.js
+++ b/frontend/app/routes/project/show/transportation/tdf/planning-factors/show.js
@@ -8,10 +8,14 @@ export default class ProjectShowTransportationTdfPlanningFactorsShowRoute extend
     const transportationPlanningFactor = await this.get('store').findRecord(
       'transportation-planning-factor',
       params.transportation_planning_factor_id, 
-      { include: 'data-package'}
+      { include: 'data-package' }
     )
-    const dataPackage = await transportationPlanningFactor.dataPackage;
-    const availablePackages = await this.get('store').query('data-package', { filter: { package: dataPackage.get('package') } });
+    const dataPackage = transportationPlanningFactor.get('dataPackage');
+    const availablePackages = await this.get('store').query('data-package', {
+      filter: {
+        package: dataPackage.get('package'),
+      }
+    });
 
     return RSVP.hash({
       project,
@@ -22,12 +26,7 @@ export default class ProjectShowTransportationTdfPlanningFactorsShowRoute extend
   }
 
   @action
-  error({ errors }, transition) {
-    const fourohfour = errors.findBy('code', '404');
-    const projectId = transition.params["project.show"].id;
-    
-    if (fourohfour) {
-      this.replaceWith('project.show.transportation.tdf.planning-factors', projectId);
-    }
+  error(error) {
+    console.log("error from project/show/transportation/tdf/planning-factors/show: ", error); // eslint-disable-line
   }
 }

--- a/frontend/app/templates/components/transportation/analysis-steps.hbs
+++ b/frontend/app/templates/components/transportation/analysis-steps.hbs
@@ -17,6 +17,7 @@
     "project.show.transportation.tdf.planning-factors"
     project.id
     class="step"
+    data-test-transportation-step="planning-factors"
   }}
     <div class="content">
       <div class="title">

--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -123,11 +123,14 @@
       <thead>
         <tr>
           <td>
-            <div class="ui small buttons">
-              <button class="ui button {{if factor.manualModeSplits 'positive'}}" onClick={{action toggleManualModeSplits}}>Manual</button>
-              <div class="or"></div>
-              <button class="ui button {{if (not factor.manualModeSplits) 'positive'}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
-            </div>
+            {{#if factor.transportationAnalysis.project.viewOnly}}
+            {{else}}
+              <div class="ui small buttons" data-test-manual-mode-toggle>
+                <button class="ui button {{if factor.manualModeSplits 'positive'}}" onClick={{action toggleManualModeSplits}}>Manual</button>
+                <div class="or"></div>
+                <button class="ui button {{if (not factor.manualModeSplits) 'positive'}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
+              </div>
+            {{/if}}
           </td>
           <td>
             {{!-- Census Tract calculations only product on period --}}

--- a/frontend/app/templates/components/transportation/trip-generation-map.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-map.hbs
@@ -4,7 +4,7 @@
   @initOptions={{hash
     style="https://layers-api.planninglabs.nyc/v1/base/style.json"
     zoom=12
-    center=this.project.transportationAnalysis.jtwStudyAreaCentroid
+    center=this.project.transportationAnalysis.censusTractsCentroid
   }} as |map|
 >
   <MapboxGlSource
@@ -103,7 +103,7 @@
         @map={{map}}
         @layerId={{layer.layerId}}
         @filterById="geoid"
-        @featureIds={{this.project.transportationAnalysis.requiredJtwStudySelection}}
+        @featureIds={{this.project.transportationAnalysis.requiredCensusTractsSelection}}
       />
     </carto-source.layer>
 

--- a/frontend/app/templates/project/show/index.hbs
+++ b/frontend/app/templates/project/show/index.hbs
@@ -77,7 +77,11 @@
         </div>
       {{/link-to}}
 
-      {{#link-to "project.show.transportation" class="ui card"}}
+      {{#link-to
+        "project.show.transportation"
+        class="ui card"
+        data-test-chapter="transportation"
+      }}
         <div class="content">
           <div class="header">
             <i class="car icon"></i>

--- a/frontend/app/templates/user/projects.hbs
+++ b/frontend/app/templates/user/projects.hbs
@@ -18,7 +18,12 @@
             {{#each model as |project|}}
               <tr class="project-row">
                 <td>
-                  {{#link-to "project.show" project.id class="project-name"}}
+                  {{#link-to
+                    "project.show"
+                    project.id
+                    class="project-name"
+                    data-test-project=project.id
+                  }}
                     {{project.name}}
                   {{/link-to}}
                   {{#if project.ceqrNumber}}

--- a/frontend/mirage/config.js
+++ b/frontend/mirage/config.js
@@ -78,6 +78,7 @@ export default function() {
   this.namespace = '/api/v1';
   this.get('/users/:id');
   this.get('/data-packages');
+  this.get('/data-packages/:id');
 
   /**
    *
@@ -179,5 +180,11 @@ export default function() {
    */
   this.get('public-schools-analyses/:id');
   this.patch('public-schools-analyses/:id');
+
+  this.get('transportation-analyses');
+  this.get('transportation-analyses/:id');
   this.patch('transportation-analyses/:id');
+
+  this.get('transportation-planning-factors');
+  this.get('transportation-planning-factors/:id');
 }

--- a/frontend/mirage/factories/data-package.js
+++ b/frontend/mirage/factories/data-package.js
@@ -1,56 +1,85 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name: 'November 2017',
-  package: 'public_schools',
-  version: 'november_2017',
-  release_date: Date.now,
-  schemas: () => {
-    return {
-      "doe_school_subdistricts": { table: "2017" },
-      "doe_lcgms": {
-        table: "2017",
-        version: "2018-09-10",
-        minYear: 2017,
-        maxYear: 2018,
-      },
-      "sca_bluebook": {
-        table: "2017",
-        minYear: 2016,
-        maxYear: 2017,
-      },
-      "doe_school_zones_ps": { table: "2018" },
-      "doe_school_zones_is": { table: "2018" },
-      "doe_school_zones_hs": { table: "2018" },
-      "sca_enrollment_pct_by_sd": { table: "2017" },
-      "sca_housing_pipeline_by_boro": {
-        minYear: 2016,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "sca_housing_pipeline_by_sd": {
-        minYear: 2016,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "sca_enrollment_projections_by_boro": {
-        minYear: 2015,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "sca_enrollment_projections_by_sd": {
-        minYear: 2015,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "doe_significant_utilization_changes": {
-        table: "062018",
-        version: "2018-02-01",
-      },
-      "sca_capital_projects": {
-        table: "2018",
-        version: "2018-12-04",
+  mapPluto: trait({
+    name: 'MapPLUTO 18v1',
+    package: 'mappluto',
+    version: '18v1',
+    releaseDate: 'Thu Feb 28 2019 19:00:00 GMT-0500 (Eastern Standard Time)',
+    schemas: {
+      mappluto: {
+        carto: 'mappluto_18v2'
       }
-    };
-  }
+    }
+  }),
+
+  nycAcs: trait({
+    name: 'ACS 5-year 2017',
+    package: 'nyc_acs',
+    version: '2017',
+    releaseDate: '2018-01-01',
+    schemas: {
+      'nyc_acs': {
+        'table': '2017'
+      },
+      'nyc_census_tract_boundaries': {
+        'table': '2010'
+      }
+    }
+  }),
+
+  publicSchools: trait({
+    name: 'November 2017',
+    package: 'public_schools',
+    version: 'november_2017',
+    releaseDate: Date.now,
+    schemas: () => {
+      return {
+        "doe_school_subdistricts": { table: "2017" },
+        "doe_lcgms": {
+          table: "2017",
+          version: "2018-09-10",
+          minYear: 2017,
+          maxYear: 2018,
+        },
+        "sca_bluebook": {
+          table: "2017",
+          minYear: 2016,
+          maxYear: 2017,
+        },
+        "doe_school_zones_ps": { table: "2018" },
+        "doe_school_zones_is": { table: "2018" },
+        "doe_school_zones_hs": { table: "2018" },
+        "sca_enrollment_pct_by_sd": { table: "2017" },
+        "sca_housing_pipeline_by_boro": {
+          minYear: 2016,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "sca_housing_pipeline_by_sd": {
+          minYear: 2016,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "sca_enrollment_projections_by_boro": {
+          minYear: 2015,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "sca_enrollment_projections_by_sd": {
+          minYear: 2015,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "doe_significant_utilization_changes": {
+          table: "062018",
+          version: "2018-02-01",
+        },
+        "sca_capital_projects": {
+          table: "2018",
+          version: "2018-12-04",
+        }
+      };
+    },
+  }),
 });

--- a/frontend/mirage/factories/project.js
+++ b/frontend/mirage/factories/project.js
@@ -1,20 +1,6 @@
-import { Factory, faker, association } from 'ember-cli-mirage';
+import { Factory, faker } from 'ember-cli-mirage';
 
-export default Factory.extend({  
-  afterCreate(project, server) {
-    server.create('public-schools-analysis', { project });
-    server.create('transportation-analysis', { project });
-    server.create('community-facilities-analysis', { project });
-  },
-
-  dataPackage: association({
-    schemas: {
-      mappluto: {
-        carto: 'mappluto_18v2'
-      }
-    }
-  }),
-
+export default Factory.extend({
   viewOnly: false,
   name: faker.address.streetName,
   buildYear: 2018,

--- a/frontend/mirage/factories/public-schools-analysis.js
+++ b/frontend/mirage/factories/public-schools-analysis.js
@@ -5,61 +5,6 @@ import { Factory, trait, association } from 'ember-cli-mirage';
 // Editing the factory directly might affect other tests.
 
 export default Factory.extend({
-  dataPackage: association({
-    name: 'November 2017',
-    package: 'public_schools',
-    version: 'november_2017',
-    release_date: Date.now,
-    schemas: () => {
-      return {
-        "doe_school_subdistricts": { table: "2017" },
-        "doe_lcgms": {
-          table: "2017",
-          version: "2018-09-10",
-          minYear: 2017,
-          maxYear: 2018,
-        },
-        "sca_bluebook": {
-          table: "2017",
-          minYear: 2016,
-          maxYear: 2017,
-        },
-        "doe_school_zones_ps": { table: "2018" },
-        "doe_school_zones_is": { table: "2018" },
-        "doe_school_zones_hs": { table: "2018" },
-        "sca_enrollment_pct_by_sd": { table: "2017" },
-        "sca_housing_pipeline_by_boro": {
-          minYear: 2016,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "sca_housing_pipeline_by_sd": {
-          minYear: 2016,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "sca_enrollment_projections_by_boro": {
-          minYear: 2015,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "sca_enrollment_projections_by_sd": {
-          minYear: 2015,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "doe_significant_utilization_changes": {
-          table: "062018",
-          version: "2018-02-01",
-        },
-        "sca_capital_projects": {
-          table: "2018",
-          version: "2018-12-04",
-        }
-      };
-    }
-  }),
-
   multipliers: () => ({
     version: "november-2018",
     districts: [
@@ -725,13 +670,6 @@ export default Factory.extend({
 }),
 
 
-
-  project: association({
-      bbls: ["3023910001"],
-      totalUnits: 500,
-      seniorUnits: 50,
-      buildYear: 2023
-    }),
   esSchoolChoice: false,
   isSchoolChoice: true,
   subdistrictsFromDb: () => [

--- a/frontend/mirage/factories/transportation-analysis.js
+++ b/frontend/mirage/factories/transportation-analysis.js
@@ -1,19 +1,34 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   trafficZone: 2,
-  requiredJtwStudySelection: () => [
+  requiredCensusTractsSelection: () => [
       "36061020300"
   ],
-  jtwStudySelection: () => [
+  censusTractsSelection: () => [
     '36061020500', '36061021100', '36061019701', '36061020701', '36061020101', '36061019900'
   ],
-  jtwStudyAreaCentroid: () => [
-    -73.964251, 40.8080809
+  censusTractsCentroid: () => {
+    return {
+      features: [
+        {
+          geometry: {
+            coordinates: [
+              -73.964251, 40.8080809
+            ],
+          },
+        },
+      ]
+    }
+  },
+  modesForAnalysis: () => [
+    "auto",
+    "taxi",
+    "bus",
+    "subway",
+    "walk",
+    "railroad"
   ],
-  project: association({
-    totalUnits: 1000,
-  }),
   inOutDists: () => {
     return {
       am: {

--- a/frontend/mirage/factories/transportation-planning-factor.js
+++ b/frontend/mirage/factories/transportation-planning-factor.js
@@ -1,0 +1,276 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  landUse: 'residential',
+  manualModeSplits: false,
+  censusTractVariables: () => [
+    {
+      "population": {
+        "moe": 569,
+        "geoid": "2332",
+        "value": 5415,
+        "variable": "population"
+      },
+      "trans_home": {
+        "moe": 153,
+        "geoid": "2332",
+        "value": 385,
+        "variable": "trans_home"
+      },
+      "trans_taxi": {
+        "moe": 154,
+        "geoid": "2332",
+        "value": 237,
+        "variable": "trans_taxi"
+      },
+      "trans_walk": {
+        "moe": 177,
+        "geoid": "2332",
+        "value": 605,
+        "variable": "trans_walk"
+      },
+      "trans_other": {
+        "moe": 28,
+        "geoid": "2332",
+        "value": 17,
+        "variable": "trans_other"
+      },
+      "trans_total": {
+        "moe": 312,
+        "geoid": "2332",
+        "value": 3210,
+        "variable": "trans_total"
+      },
+      "trans_auto_2": {
+        "moe": 32,
+        "geoid": "2332",
+        "value": 30,
+        "variable": "trans_auto_2"
+      },
+      "trans_auto_3": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_auto_3"
+      },
+      "trans_auto_4": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_auto_4"
+      },
+      "trans_bicycle": {
+        "moe": 68,
+        "geoid": "2332",
+        "value": 82,
+        "variable": "trans_bicycle"
+      },
+      "trans_auto_solo": {
+        "moe": 96,
+        "geoid": "2332",
+        "value": 135,
+        "variable": "trans_auto_solo"
+      },
+      "trans_auto_total": {
+        "moe": 99,
+        "geoid": "2332",
+        "value": 165,
+        "variable": "trans_auto_total"
+      },
+      "trans_motorcycle": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_motorcycle"
+      },
+      "trans_public_bus": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_public_bus"
+      },
+      "trans_auto_5_or_6": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_auto_5_or_6"
+      },
+      "trans_public_rail": {
+        "moe": 74,
+        "geoid": "2332",
+        "value": 77,
+        "variable": "trans_public_rail"
+      },
+      "trans_public_ferry": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_public_ferry"
+      },
+      "trans_public_total": {
+        "moe": 300,
+        "geoid": "2332",
+        "value": 1719,
+        "variable": "trans_public_total"
+      },
+      "trans_public_subway": {
+        "moe": 291,
+        "geoid": "2332",
+        "value": 1642,
+        "variable": "trans_public_subway"
+      },
+      "trans_auto_7_or_more": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_auto_7_or_more"
+      },
+      "trans_public_streetcar": {
+        "moe": 16,
+        "geoid": "2332",
+        "value": 0,
+        "variable": "trans_public_streetcar"
+      },
+      "trans_auto_carpool_total": {
+        "moe": null,
+        "geoid": "2332",
+        "value": null,
+        "variable": "trans_auto_carpool_total"
+      }
+    },
+    {
+      "population": {
+        "moe": 315,
+        "geoid": "2372",
+        "value": 2674,
+        "variable": "population"
+      },
+      "trans_home": {
+        "moe": 54,
+        "geoid": "2372",
+        "value": 118,
+        "variable": "trans_home"
+      },
+      "trans_taxi": {
+        "moe": 67,
+        "geoid": "2372",
+        "value": 113,
+        "variable": "trans_taxi"
+      },
+      "trans_walk": {
+        "moe": 127,
+        "geoid": "2372",
+        "value": 458,
+        "variable": "trans_walk"
+      },
+      "trans_other": {
+        "moe": 52,
+        "geoid": "2372",
+        "value": 33,
+        "variable": "trans_other"
+      },
+      "trans_total": {
+        "moe": 263,
+        "geoid": "2372",
+        "value": 1689,
+        "variable": "trans_total"
+      },
+      "trans_auto_2": {
+        "moe": 43,
+        "geoid": "2372",
+        "value": 36,
+        "variable": "trans_auto_2"
+      },
+      "trans_auto_3": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_auto_3"
+      },
+      "trans_auto_4": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_auto_4"
+      },
+      "trans_bicycle": {
+        "moe": 40,
+        "geoid": "2372",
+        "value": 50,
+        "variable": "trans_bicycle"
+      },
+      "trans_auto_solo": {
+        "moe": 48,
+        "geoid": "2372",
+        "value": 72,
+        "variable": "trans_auto_solo"
+      },
+      "trans_auto_total": {
+        "moe": 70,
+        "geoid": "2372",
+        "value": 108,
+        "variable": "trans_auto_total"
+      },
+      "trans_motorcycle": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_motorcycle"
+      },
+      "trans_public_bus": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_public_bus"
+      },
+      "trans_auto_5_or_6": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_auto_5_or_6"
+      },
+      "trans_public_rail": {
+        "moe": 14,
+        "geoid": "2372",
+        "value": 9,
+        "variable": "trans_public_rail"
+      },
+      "trans_public_ferry": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_public_ferry"
+      },
+      "trans_public_total": {
+        "moe": 195,
+        "geoid": "2372",
+        "value": 809,
+        "variable": "trans_public_total"
+      },
+      "trans_public_subway": {
+        "moe": 195,
+        "geoid": "2372",
+        "value": 800,
+        "variable": "trans_public_subway"
+      },
+      "trans_auto_7_or_more": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_auto_7_or_more"
+      },
+      "trans_public_streetcar": {
+        "moe": 11,
+        "geoid": "2372",
+        "value": 0,
+        "variable": "trans_public_streetcar"
+      },
+      "trans_auto_carpool_total": {
+        "moe": null,
+        "geoid": "2372",
+        "value": null,
+        "variable": "trans_auto_carpool_total"
+      }
+    },
+  ],
+});

--- a/frontend/mirage/models/data-package.js
+++ b/frontend/mirage/models/data-package.js
@@ -1,4 +1,6 @@
-import { Model } from 'ember-cli-mirage';
+import { Model, hasMany} from 'ember-cli-mirage';
 
 export default Model.extend({
+  project: hasMany(),
+  transportationPlanningFactors: hasMany(),
 });

--- a/frontend/mirage/models/transportation-analysis.js
+++ b/frontend/mirage/models/transportation-analysis.js
@@ -1,5 +1,6 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   project: belongsTo(),
+  transportationPlanningFactors: hasMany(),
 });

--- a/frontend/mirage/models/transportation-planning-factor.js
+++ b/frontend/mirage/models/transportation-planning-factor.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  transportationAnalysis: belongsTo(),
+  dataPackage: belongsTo(),
+});

--- a/frontend/tests/acceptance/492-view-only-transportation-test.js
+++ b/frontend/tests/acceptance/492-view-only-transportation-test.js
@@ -1,0 +1,73 @@
+import { module, test } from 'qunit';
+import { visit, fillIn, click, find } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | 492 view only transportation', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('User can to toggle Manual Modal Splits when project is not viewOnly', async function(assert) {
+    server.logging = true;
+
+    this.server.create('user');
+    this.server.create('project', {
+      publicSchoolsAnalysis: this.server.create('publicSchoolsAnalysis'),
+      transportationAnalysis: this.server.create('transportationAnalysis', {
+        transportationPlanningFactors: [
+          this.server.create('transportationPlanningFactor', {
+            landUse: 'residential',
+            dataPackage: this.server.create('dataPackage', 'nycAcs'),
+          }),
+        ],
+       }),
+       communityFacilitiesAnalysis: this.server.create('communityFacilitiesAnalysis'),
+       viewOnly: false,
+    });
+
+    await visit('/');
+    await fillIn('[data-test-login-form="email"]', 'user@email.com');
+    await fillIn('[data-test-login-form="password"]', 'password');
+    await click('[data-test-login-form="login"]');
+
+    await click('[data-test-project="1"]');
+
+    await click('[data-test-chapter="transportation"]');
+
+    await click('[data-test-transportation-step="planning-factors"]');
+
+    await assert.ok(find('[data-test-manual-mode-toggle]'));
+  });
+
+  test('User cannot toggle to Manual Modal Splits when project is viewOnly', async function(assert) {
+    server.logging = true;
+
+    this.server.create('user');
+    this.server.create('project', {
+      publicSchoolsAnalysis: this.server.create('publicSchoolsAnalysis'),
+      transportationAnalysis: this.server.create('transportationAnalysis', {
+        transportationPlanningFactors: [
+          this.server.create('transportationPlanningFactor', {
+            landUse: 'residential',
+            dataPackage: this.server.create('dataPackage', 'nycAcs'),
+          }),
+        ],
+       }),
+       communityFacilitiesAnalysis: this.server.create('communityFacilitiesAnalysis'),
+       viewOnly: true,
+    });
+
+    await visit('/');
+    await fillIn('[data-test-login-form="email"]', 'user@email.com');
+    await fillIn('[data-test-login-form="password"]', 'password');
+    await click('[data-test-login-form="login"]');
+
+    await click('[data-test-project="1"]');
+
+    await click('[data-test-chapter="transportation"]');
+
+    await click('[data-test-transportation-step="planning-factors"]');
+
+    await assert.notOk(find('[data-test-manual-mode-toggle]'));
+  });
+});

--- a/frontend/tests/unit/models/public-schools-analysis-test.js
+++ b/frontend/tests/unit/models/public-schools-analysis-test.js
@@ -240,6 +240,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
           subdistrict: 5
         }
       ],
+      project: this.server.create('project'),
     });
     let project = await this.owner.lookup('service:store').findRecord(
       'project', analysisMirage.projectId, { include: 'public-schools-analysis' }
@@ -322,17 +323,19 @@ module('Unit | Model | public schools analysis', function(hooks) {
     */
 
     // project with build year 2027
-    let analysisMirage2027 = server.create('public-schools-analysis', {
-      project: association({
+    let analysisMirage2027 = this.server.create('public-schools-analysis', {
+      project: this.server.create('project', {
         buildYear: 2027
-      })
+      }),
+      dataPackage: this.server.create('data-package', 'publicSchools'),
     });
 
     // project with build year 2024
-    let analysisMirage2024 = server.create('public-schools-analysis', {
-      project: association({
-        buildYear: 2024
-      })
+    let analysisMirage2024 = this.server.create('public-schools-analysis', {
+      project: this.server.create('project', {
+        buildYear: 2024,
+      }),
+      dataPackage: this.server.create('data-package', 'publicSchools'),
     });
 
     let analysis2024 = await this.owner.lookup('service:store').findRecord(
@@ -385,6 +388,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
     */
 
     let analysisMirage = server.create('public-schools-analysis', {
+      project: this.server.create('project'),
       doeUtilChanges: [
         {
           title: "",


### PR DESCRIPTION
This PR contains bugfixes and foundational mirage architecture (models, factories, routes) to get acceptance testing set up for the `project/show/transportation/tdf/planning-factors/show` route. It also

- Provides a basic acceptance test example for the `.../planning-factors/show` route
- improves error logging in routes.

Currently CircleCI is failing I think because of failed carto requests. We may need to return static `.mvt` files for those failed carto requests, like in zap-search.