### PR TITLE
Switch to heroku-based layers-api

### DIFF
--- a/frontend/app/templates/components/project/project-area-selector-map.hbs
+++ b/frontend/app/templates/components/project/project-area-selector-map.hbs
@@ -2,7 +2,7 @@
   @name="project-area-selector-map"
   @mapLoaded={{action this.mapLoaded}}
   @initOptions={{hash
-    style="https://layers-api.planninglabs.nyc/v1/base/style.json"
+    style="https://labs-layers-api.herokuapp.com/v1/base/style.json"
   }} as |map|
 >
   <Mapbox::CartoVectorSource @sourceId="carto" @map={{map}} as |carto-source|>

--- a/frontend/app/templates/components/public-schools/project-map.hbs
+++ b/frontend/app/templates/components/public-schools/project-map.hbs
@@ -2,7 +2,7 @@
   @id="study-area-map"
   @mapLoaded={{action "handleMapLoad"}}
   @initOptions={{hash
-    style="https://layers-api.planninglabs.nyc/v1/base/style.json"
+    style="https://labs-layers-api.herokuapp.com/v1/base/style.json"
     zoom=9.2
     center=(array -74 40.7071266)
   }} as |map|

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map.hbs
@@ -2,7 +2,7 @@
   @name="census-tracts-map"
   @mapLoaded={{action this.mapLoaded}}
   @initOptions={{hash
-    style="https://layers-api.planninglabs.nyc/v1/base/style.json"
+    style="https://labs-layers-api.herokuapp.com/v1/base/style.json"
     zoom=14
     center=censusTractsCentroidLngLat
   }} as |map|

--- a/frontend/app/templates/components/transportation/trip-generation-map.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-map.hbs
@@ -2,7 +2,7 @@
   @name="trip-generation-map"
   @mapLoaded={{action this.mapLoaded}}
   @initOptions={{hash
-    style="https://layers-api.planninglabs.nyc/v1/base/style.json"
+    style="https://labs-layers-api.herokuapp.com/v1/base/style.json"
     zoom=12
     center=this.project.transportationAnalysis.jtwStudyAreaCentroid
   }} as |map|

--- a/frontend/mirage/config.js
+++ b/frontend/mirage/config.js
@@ -15,7 +15,7 @@ export default function() {
   this.passthrough('/data-tables/**');
   this.passthrough('/ceqr-manual/**');
   this.passthrough('https://api.mapbox.com/**');
-  this.passthrough('https://layers-api.planninglabs.nyc/**');
+  this.passthrough('https://labs-layers-api.herokuapp.com/**');
   this.passthrough('https://tiles.planninglabs.nyc/**');
   this.passthrough('https://events.mapbox.com/events/**');
   


### PR DESCRIPTION
Switches over to the Heroku-based deployment of our Layers API.