### PR TITLE
Replace old jtw* variable names w censusTracts*

### DIFF
--- a/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map/study-selection-toggler.js
+++ b/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map/study-selection-toggler.js
@@ -28,7 +28,7 @@ export default class TransportationCensusTractsMapStudySelectionTogglerComponent
 
   /**
    * Method to handle feature selection; adds a selected feature geoid to the analysis'
-   * jtwStudySelection array, or removes it if it already exists, and saves the analysis model
+   * censusTractsSelection array, or removes it if it already exists, and saves the analysis model
    * back to the server
    */
   async toggleCensusTract(selectedCensusTractFeatureArray) {    

--- a/frontend/app/templates/components/transportation/trip-generation-map.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-map.hbs
@@ -4,7 +4,7 @@
   @initOptions={{hash
     style="https://layers-api.planninglabs.nyc/v1/base/style.json"
     zoom=12
-    center=this.project.transportationAnalysis.jtwStudyAreaCentroid
+    center=this.project.transportationAnalysis.censusTractsCentroid
   }} as |map|
 >
   <MapboxGlSource
@@ -103,7 +103,7 @@
         @map={{map}}
         @layerId={{layer.layerId}}
         @filterById="geoid"
-        @featureIds={{this.project.transportationAnalysis.requiredJtwStudySelection}}
+        @featureIds={{this.project.transportationAnalysis.requiredCensusTractsSelection}}
       />
     </carto-source.layer>
 

--- a/frontend/mirage/factories/transportation-analysis.js
+++ b/frontend/mirage/factories/transportation-analysis.js
@@ -2,13 +2,13 @@ import { Factory, association } from 'ember-cli-mirage';
 
 export default Factory.extend({
   trafficZone: 2,
-  requiredJtwStudySelection: () => [
+  requiredCensusTractsSelection: () => [
       "36061020300"
   ],
-  jtwStudySelection: () => [
+  censusTractsSelection: () => [
     '36061020500', '36061021100', '36061019701', '36061020701', '36061020101', '36061019900'
   ],
-  jtwStudyAreaCentroid: () => [
+  censusTractsCentroid: () => [
     -73.964251, 40.8080809
   ],
   project: association({


### PR DESCRIPTION
The jtw* variable names are old and no longer used, so update them to the correct current variable names. 

See `frontend/mirage/factories/transportation-analysis.js` for the mapping between old and new names. 