### PR TITLE
Define and load Data Packages using traits when testing

### DIFF
--- a/frontend/mirage/factories/data-package.js
+++ b/frontend/mirage/factories/data-package.js
@@ -1,56 +1,85 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name: 'November 2017',
-  package: 'public_schools',
-  version: 'november_2017',
-  release_date: Date.now,
-  schemas: () => {
-    return {
-      "doe_school_subdistricts": { table: "2017" },
-      "doe_lcgms": {
-        table: "2017",
-        version: "2018-09-10",
-        minYear: 2017,
-        maxYear: 2018,
-      },
-      "sca_bluebook": {
-        table: "2017",
-        minYear: 2016,
-        maxYear: 2017,
-      },
-      "doe_school_zones_ps": { table: "2018" },
-      "doe_school_zones_is": { table: "2018" },
-      "doe_school_zones_hs": { table: "2018" },
-      "sca_enrollment_pct_by_sd": { table: "2017" },
-      "sca_housing_pipeline_by_boro": {
-        minYear: 2016,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "sca_housing_pipeline_by_sd": {
-        minYear: 2016,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "sca_enrollment_projections_by_boro": {
-        minYear: 2015,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "sca_enrollment_projections_by_sd": {
-        minYear: 2015,
-        maxYear: 2025,
-        table: "2017",
-      },
-      "doe_significant_utilization_changes": {
-        table: "062018",
-        version: "2018-02-01",
-      },
-      "sca_capital_projects": {
-        table: "2018",
-        version: "2018-12-04",
+  mapPluto: trait({
+    name: 'MapPLUTO 18v1',
+    package: 'mappluto',
+    version: '18v1',
+    releaseDate: 'Thu Feb 28 2019 19:00:00 GMT-0500 (Eastern Standard Time)',
+    schemas: {
+      mappluto: {
+        carto: 'mappluto_18v2'
       }
-    };
-  }
+    }
+  }),
+
+  nycAcs: trait({
+    name: 'ACS 5-year 2017',
+    package: 'nyc_acs',
+    version: '2017',
+    releaseDate: '2018-01-01',
+    schemas: {
+      'nyc_acs': {
+        'table': '2017'
+      },
+      'nyc_census_tract_boundaries': {
+        'table': '2010'
+      }
+    }
+  }),
+
+  publicSchools: trait({
+    name: 'November 2017',
+    package: 'public_schools',
+    version: 'november_2017',
+    releaseDate: Date.now,
+    schemas: () => {
+      return {
+        "doe_school_subdistricts": { table: "2017" },
+        "doe_lcgms": {
+          table: "2017",
+          version: "2018-09-10",
+          minYear: 2017,
+          maxYear: 2018,
+        },
+        "sca_bluebook": {
+          table: "2017",
+          minYear: 2016,
+          maxYear: 2017,
+        },
+        "doe_school_zones_ps": { table: "2018" },
+        "doe_school_zones_is": { table: "2018" },
+        "doe_school_zones_hs": { table: "2018" },
+        "sca_enrollment_pct_by_sd": { table: "2017" },
+        "sca_housing_pipeline_by_boro": {
+          minYear: 2016,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "sca_housing_pipeline_by_sd": {
+          minYear: 2016,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "sca_enrollment_projections_by_boro": {
+          minYear: 2015,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "sca_enrollment_projections_by_sd": {
+          minYear: 2015,
+          maxYear: 2025,
+          table: "2017",
+        },
+        "doe_significant_utilization_changes": {
+          table: "062018",
+          version: "2018-02-01",
+        },
+        "sca_capital_projects": {
+          table: "2018",
+          version: "2018-12-04",
+        }
+      };
+    },
+  }),
 });

--- a/frontend/mirage/factories/project.js
+++ b/frontend/mirage/factories/project.js
@@ -1,20 +1,11 @@
-import { Factory, faker, association } from 'ember-cli-mirage';
+import { Factory, faker } from 'ember-cli-mirage';
 
-export default Factory.extend({  
+export default Factory.extend({
   afterCreate(project, server) {
     server.create('public-schools-analysis', { project });
     server.create('transportation-analysis', { project });
     server.create('community-facilities-analysis', { project });
   },
-
-  dataPackage: association({
-    schemas: {
-      mappluto: {
-        carto: 'mappluto_18v2'
-      }
-    }
-  }),
-
   viewOnly: false,
   name: faker.address.streetName,
   buildYear: 2018,

--- a/frontend/mirage/factories/public-schools-analysis.js
+++ b/frontend/mirage/factories/public-schools-analysis.js
@@ -5,61 +5,6 @@ import { Factory, trait, association } from 'ember-cli-mirage';
 // Editing the factory directly might affect other tests.
 
 export default Factory.extend({
-  dataPackage: association({
-    name: 'November 2017',
-    package: 'public_schools',
-    version: 'november_2017',
-    release_date: Date.now,
-    schemas: () => {
-      return {
-        "doe_school_subdistricts": { table: "2017" },
-        "doe_lcgms": {
-          table: "2017",
-          version: "2018-09-10",
-          minYear: 2017,
-          maxYear: 2018,
-        },
-        "sca_bluebook": {
-          table: "2017",
-          minYear: 2016,
-          maxYear: 2017,
-        },
-        "doe_school_zones_ps": { table: "2018" },
-        "doe_school_zones_is": { table: "2018" },
-        "doe_school_zones_hs": { table: "2018" },
-        "sca_enrollment_pct_by_sd": { table: "2017" },
-        "sca_housing_pipeline_by_boro": {
-          minYear: 2016,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "sca_housing_pipeline_by_sd": {
-          minYear: 2016,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "sca_enrollment_projections_by_boro": {
-          minYear: 2015,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "sca_enrollment_projections_by_sd": {
-          minYear: 2015,
-          maxYear: 2025,
-          table: "2017",
-        },
-        "doe_significant_utilization_changes": {
-          table: "062018",
-          version: "2018-02-01",
-        },
-        "sca_capital_projects": {
-          table: "2018",
-          version: "2018-12-04",
-        }
-      };
-    }
-  }),
-
   multipliers: () => ({
     version: "november-2018",
     districts: [

--- a/frontend/tests/unit/models/public-schools-analysis-test.js
+++ b/frontend/tests/unit/models/public-schools-analysis-test.js
@@ -322,17 +322,19 @@ module('Unit | Model | public schools analysis', function(hooks) {
     */
 
     // project with build year 2027
-    let analysisMirage2027 = server.create('public-schools-analysis', {
-      project: association({
+    let analysisMirage2027 = this.server.create('public-schools-analysis', {
+      project: this.server.create('project', {
         buildYear: 2027
-      })
+      }),
+      dataPackage: this.server.create('data-package', 'publicSchools'),
     });
 
     // project with build year 2024
-    let analysisMirage2024 = server.create('public-schools-analysis', {
-      project: association({
-        buildYear: 2024
-      })
+    let analysisMirage2024 = this.server.create('public-schools-analysis', {
+      project: this.server.create('project', {
+        buildYear: 2024,
+      }),
+      dataPackage: this.server.create('data-package', 'publicSchools'),
     });
 
     let analysis2024 = await this.owner.lookup('service:store').findRecord(


### PR DESCRIPTION
This PR better organizes and cleans up Data Package values in testing by...

1) Introducing traits into the Data Package factory.
2) Moving Data Package creation out of factory files and into test files.
3) Removing use of the `association` helper in tests to create one-off data packages with each Project or Analysis (this is also necessary to help remove circular mirage dependencies, which will be fully addressed in a later PR)

Projects and Analyses are both related to Data Packages. In their mirage factories, previously  the `association` helper was used to create one-off Data Packages. This meant a particularly long Data Package value within the `public-schools-analysis` factory file.