### PR TITLE
Remove unintended side effects of creating mirage Analysis

### DIFF
--- a/frontend/mirage/factories/project.js
+++ b/frontend/mirage/factories/project.js
@@ -1,11 +1,6 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  afterCreate(project, server) {
-    server.create('public-schools-analysis', { project });
-    server.create('transportation-analysis', { project });
-    server.create('community-facilities-analysis', { project });
-  },
   viewOnly: false,
   name: faker.address.streetName,
   buildYear: 2018,

--- a/frontend/mirage/factories/public-schools-analysis.js
+++ b/frontend/mirage/factories/public-schools-analysis.js
@@ -670,13 +670,6 @@ export default Factory.extend({
 }),
 
 
-
-  project: association({
-      bbls: ["3023910001"],
-      totalUnits: 500,
-      seniorUnits: 50,
-      buildYear: 2023
-    }),
   esSchoolChoice: false,
   isSchoolChoice: true,
   subdistrictsFromDb: () => [

--- a/frontend/mirage/factories/transportation-analysis.js
+++ b/frontend/mirage/factories/transportation-analysis.js
@@ -1,4 +1,4 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   trafficZone: 2,
@@ -11,9 +11,6 @@ export default Factory.extend({
   censusTractsCentroid: () => [
     -73.964251, 40.8080809
   ],
-  project: association({
-    totalUnits: 1000,
-  }),
   inOutDists: () => {
     return {
       am: {

--- a/frontend/tests/unit/models/public-schools-analysis-test.js
+++ b/frontend/tests/unit/models/public-schools-analysis-test.js
@@ -240,6 +240,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
           subdistrict: 5
         }
       ],
+      project: this.server.create('project'),
     });
     let project = await this.owner.lookup('service:store').findRecord(
       'project', analysisMirage.projectId, { include: 'public-schools-analysis' }
@@ -387,6 +388,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
     */
 
     let analysisMirage = server.create('public-schools-analysis', {
+      project: this.server.create('project'),
       doeUtilChanges: [
         {
           title: "",


### PR DESCRIPTION
Previously, Analysis factories created their own one-off Projects. However the Project factory also created three Analyses for itself (and each Analysis then in turn created their own one-off Projects). Thus creating an Analysis in mirage had the unintended consequence of creating multiple projects in the application.

This problem is fixed by removing the one-off Project `association`s from Analysis factories, and also removing the Project factory's `afterCreate` hook which created three analyses for a project. Now Project-Analysis relationships need to be explicitly defined in tests.

Tests have experienced some flakiness.  Ember test error `cannot read tilejson of undefined` was fixed by simply re-running tests. May need to look into setting up mock `.mvt`s/protobuffs in this app. 