### PR TITLE
543 Install template linting

### DIFF
--- a/frontend/.template-lintrc.js
+++ b/frontend/.template-lintrc.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+'use strict';
+
 module.exports = {
   extends: 'recommended',
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,8 +36,12 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Linting
 
+#### Javascript
 * `yarn lint:js`
 * `yarn lint:js --fix`
+
+#### Handlebars
+* `yarn lint:hbs`
 
 ### Building
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js app config lib server tests",
+    "lint:hbs": "ember-template-lint .",
     "start": "ember serve",
     "test": "ember test",
     "start-with-backend": "HOST='http://localhost:3000' DISABLE_MIRAGE=true ember s"
@@ -82,6 +83,7 @@
     "ember-simple-auth-token": "^4.0.6",
     "ember-source": "~3.7.3",
     "ember-sticky-element": "^0.2.3",
+    "ember-template-lint": "^1.13.0",
     "ember-test-selectors": "2.1.0",
     "ember-truth-helpers": "^2.1.0",
     "ember-window-mock": "^0.5.4",


### PR DESCRIPTION
Install template linting capabilities using the `ember-template-lint` package, but hold off on enabling it during builds (`ember s` or `ember test`) so that this PR can be merge. For now, developers can manually run template linting by using `yarn lint:hbs` or `npm run lint:hbs`.

In the future, when we are ready to introduce template linting in tests, we can install `ember-cli-template-lint`, which will automatically add template lint tests to the test suite.

Currently, even after keeping some template lint rules disabled, there is a lot of cleanup that needs to happen before handlebar linting tests pass. Mostly the errors are about replacing single quotes with double quotes. 

See CI log for failed lint tests. 

There will be another subsequent PR that fixes all handlebar linting errors at once. 