### PR TITLE
554 Fix all template linting errors & 553 add template linting tests

### DIFF
--- a/frontend/app/templates/application.hbs
+++ b/frontend/app/templates/application.hbs
@@ -17,7 +17,7 @@
           </strong>
           <span class="soft">
             is a project of NYC Planning in collaboration with
-            <br />
+            <br>
             the Mayor's Office of Environmental Coordination
           </span>
         </p>
@@ -32,8 +32,7 @@
                 class="planning-logo"
                 alt="NYC Planning logo"
                 src="/imgs/dcp_logo_772.png"
-               />
-
+              >
             </a>
           </div>
           <div class="item">
@@ -46,7 +45,7 @@
                 class="moec-logo"
                 alt="Mayor's Office of Environmental Coordination logo"
                 src="/imgs/moec_logo.png"
-               />
+              >
 
             </a>
           </div>

--- a/frontend/app/templates/ceqr-intro-page.hbs
+++ b/frontend/app/templates/ceqr-intro-page.hbs
@@ -22,11 +22,15 @@
     </div>
 
     <br>
-    <a href="mailto:Labs_DL@planning.nyc.gov" target="_blank"><font color="#3232ff">Email Us</font></a>
+    <a href="mailto:Labs_DL@planning.nyc.gov" target="_blank" rel="noopener">
+      <font color="#3232ff">Email Us</font>
+    </a>
 
     <br>
     <br>
-    <p><img src="/imgs/ceqr_manual_cover_814x539.png" /></p>
+    <p>
+      <img src="/imgs/ceqr_manual_cover_814x539.png" alt="ceqr manual cover">
+    </p>
 
   </div>
 </div>

--- a/frontend/app/templates/components/project/project-area-selector-map.hbs
+++ b/frontend/app/templates/components/project/project-area-selector-map.hbs
@@ -7,21 +7,21 @@
 >
   <Mapbox::CartoVectorSource @sourceId="carto" @map={{map}} as |carto-source|>
     <carto-source.layer
-      @id='pluto-line'
+      @id="pluto-line"
       @sql={{mapplutoSql}}
       @layer={{hash
-        type='line'
-        paint=(get-layer-style 'pluto-line' 'paint')
+        type="line"
+        paint=(get-layer-style "pluto-line" "paint")
       }}
     />
 
     <carto-source.layer
-      @id='pluto-labels'
+      @id="pluto-labels"
       @sql={{mapplutoSql}}
       @layer={{hash
-        type='symbol'
-        layout=(get-layer-style 'pluto-labels' 'layout')
-        paint=(get-layer-style 'pluto-labels' 'paint')
+        type="symbol"
+        layout=(get-layer-style "pluto-labels" "layout")
+        paint=(get-layer-style "pluto-labels" "paint")
       }}
     />
 
@@ -30,7 +30,7 @@
       @sql={{mapplutoSql}}
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-content' 'paint')
+        paint=(get-layer-style "selectable-feature-content" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureHoverer
@@ -55,8 +55,8 @@
       @sql={{mapplutoSql}}
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-line' 'paint')
-        layout=(get-layer-style 'selectable-feature-line' 'layout')
+        paint=(get-layer-style "selectable-feature-line" "paint")
+        layout=(get-layer-style "selectable-feature-line" "layout")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -72,7 +72,7 @@
       @sql={{mapplutoSql}}
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'bbls' 'paint')
+        paint=(get-layer-style "bbls" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer

--- a/frontend/app/templates/components/public-schools/analysis-steps.hbs
+++ b/frontend/app/templates/components/public-schools/analysis-steps.hbs
@@ -34,7 +34,7 @@
       </div>
       <div class="description">
         Future school conditions
-        <br />
+        <br>
         without proposed project
       </div>
     </div>
@@ -46,7 +46,7 @@
       </div>
       <div class="description">
         Future school conditions
-        <br />
+        <br>
         with proposed project
       </div>
     </div>

--- a/frontend/app/templates/components/public-schools/analysis-threshold/mar-twenty-fourteen-multipliers.hbs
+++ b/frontend/app/templates/components/public-schools/analysis-threshold/mar-twenty-fourteen-multipliers.hbs
@@ -4,12 +4,12 @@
       <th></th>
       <th colspan="3">
         Estimated Public School Students Generated
-        <br />
+        <br>
         by New Residential Units
       </th>
       <th colspan="2">
         Minimum Number of Residential Units that
-        <br />
+        <br>
         Trigger Detailed Analyses
       </th>
     </tr>
@@ -17,28 +17,28 @@
       <th></th>
       <th>
         Elementary
-        <br />
+        <br>
         level per unit
-        <br />
+        <br>
         (Age 4-10)
       </th>
       <th>
         Middle School
-        <br />
+        <br>
         level per unit
-        <br />
+        <br>
         (Age 11-13)
       </th>
       <th>
         High School
-        <br />
+        <br>
         level per unit
-        <br />
+        <br>
         (Age 14-17)
       </th>
       <th>
         Primary/
-        <br />
+        <br>
         Intermediate
       </th>
       <th>

--- a/frontend/app/templates/components/public-schools/analysis-threshold/nov-twenty-eighteen-multipliers.hbs
+++ b/frontend/app/templates/components/public-schools/analysis-threshold/nov-twenty-eighteen-multipliers.hbs
@@ -7,7 +7,7 @@
       </th>
       <th colspan="2">
         Minimum Number of Residential Units
-        <br />
+        <br>
         that Trigger Detailed Analyses
       </th>
     </tr>
@@ -15,33 +15,33 @@
       <th></th>
       <th>
         School
-        <br />
+        <br>
         District
       </th>
       <th>
         Primary School
-        <br />
+        <br>
         level per unit
-        <br />
+        <br>
         (Age 4-10)
       </th>
       <th>
         Intermediate School
-        <br />
+        <br>
         level per unit
-        <br />
+        <br>
         (Age 11-13)
       </th>
       <th>
         High School
-        <br />
+        <br>
         level per unit
-        <br />
+        <br>
         (Age 14-17)
       </th>
       <th>
         Primary/
-        <br />
+        <br>
         Intermediate
       </th>
       <th>

--- a/frontend/app/templates/components/public-schools/analysis-threshold/threshold-result.hbs
+++ b/frontend/app/templates/components/public-schools/analysis-threshold/threshold-result.hbs
@@ -10,7 +10,7 @@
       </th>
       <th class="three wide" colspan="2">
         Est. # of students
-        <br />
+        <br>
         from analysis
       </th>
       <th class="three wide">

--- a/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
@@ -49,12 +49,12 @@
         </th>
         <th class="one wide">
           Target
-          <br />
+          <br>
           Capacity
         </th>
         <th class="one wide">
           Available
-          <br />
+          <br>
           Seats
         </th>
         <th class="one wide">
@@ -79,7 +79,7 @@
             </i>
             {{b.name}}
             {{#if (not-eq b.name b.bldg_name)}}
-              <br />
+              <br>
               <em>
                 {{b.bldg_name}}
               </em>

--- a/frontend/app/templates/components/public-schools/existing-conditions/table-existing-conditions.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/table-existing-conditions.hbs
@@ -63,12 +63,12 @@
       </th>
       <th class="one wide">
         Target
-        <br />
+        <br>
         Capacity
       </th>
       <th class="one wide">
         Available
-        <br />
+        <br>
         Seats
       </th>
       <th class="one wide">
@@ -99,7 +99,7 @@
           {{/if}}
           {{b.name}}
           {{#if (not-eq b.name b.bldg_name)}}
-            <br />
+            <br>
             <em>
               {{b.bldg_name}}
             </em>

--- a/frontend/app/templates/components/public-schools/no-action/no-action-steps.hbs
+++ b/frontend/app/templates/components/public-schools/no-action/no-action-steps.hbs
@@ -13,7 +13,7 @@
       class="item"
     }}
       SCA Schools
-      <br />
+      <br>
       Under Construction
       <div
         class="ui label
@@ -28,7 +28,7 @@
       class="item"
     }}
       DOE Significant
-      <br />
+      <br>
       Utilization Changes
       <div
         class="ui label
@@ -43,7 +43,7 @@
       class="item"
     }}
       Additional
-      <br />
+      <br>
       Residential Development
       {{#if (gt analysis.futureResidentialDev.length 0)}}
         <div class="ui label blue">

--- a/frontend/app/templates/components/public-schools/project-map.hbs
+++ b/frontend/app/templates/components/public-schools/project-map.hbs
@@ -153,7 +153,7 @@
       @layer={{hash
         id="bbls"
         type="line"
-        paint=(get-layer-style 'bbls' 'paint')
+        paint=(get-layer-style "bbls" "paint")
       }}
      />
 

--- a/frontend/app/templates/components/public-schools/with-action/steps.hbs
+++ b/frontend/app/templates/components/public-schools/with-action/steps.hbs
@@ -13,7 +13,7 @@
       class="item"
     }}
       With Action
-      <br />
+      <br>
       Additional Schools
       <div class="ui label blue">
         {{analysis.schoolsWithAction.length}}

--- a/frontend/app/templates/components/transportation/census-tracts-table.hbs
+++ b/frontend/app/templates/components/transportation/census-tracts-table.hbs
@@ -20,7 +20,7 @@
         <th class="one wide" colspan="1">
           Percent
         </th>
-        {{#each this.selectedCensusTractIds as |censusTract|}}
+        {{#each this.selectedCensusTractIds}}
           <th class="one wide" colspan="1">
             Count
           </th>
@@ -58,7 +58,7 @@
         <tr style="background-color: rgb(249, 250, 251)">
           <td></td>
           <td colspan="2">Average</td>
-          <td colspan="{{mult censusTracts.length 2}}"></td>
+          <td colspan={{mult censusTracts.length 2}}></td>
         </tr>
         <tr>
           <td>&nbsp;&nbsp;&nbsp;Vehicle Occupancy</td>

--- a/frontend/app/templates/components/transportation/land-use-menu.hbs
+++ b/frontend/app/templates/components/transportation/land-use-menu.hbs
@@ -8,7 +8,7 @@
             factor.id
             class="item"
           }}
-            <span data-test-land-use-tab="{{factor.landUse}}">{{humanize factor.landUse}}</span>
+            <span data-test-land-use-tab={{factor.landUse}}>{{humanize factor.landUse}}</span>
             <div class="ui horizontal label">
               {{pluralize (format-number factor.units) factor.unitName}}
             </div>

--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -13,16 +13,16 @@
         <tr>
           <td class="four wide">
             <div class="ui small buttons">
-              <button class="ui button {{if factor.manualModeSplits 'positive'}}" onClick={{action toggleManualModeSplits}}>Manual</button>
+              <button class="ui button {{if factor.manualModeSplits "positive"}}" onClick={{action toggleManualModeSplits}}>Manual</button>
               <div class="or"></div>
-              <button class="ui button {{if (not factor.manualModeSplits) 'positive'}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
+              <button class="ui button {{if (not factor.manualModeSplits) "positive"}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
             </div>
           </td>
           <td colspan={{if factor.temporalModeSplits "4" "1"}}>
             <div class="ui small buttons">
-              <button class="ui button {{if factor.temporalModeSplits 'positive'}}" onClick={{action toggleTemporalModeSplits true}}>Temporal Splits</button>
+              <button class="ui button {{if factor.temporalModeSplits "positive"}}" onClick={{action toggleTemporalModeSplits true}}>Temporal Splits</button>
               <div class="or"></div>
-              <button class="ui button {{if (not factor.temporalModeSplits) 'positive'}}" onClick={{action toggleTemporalModeSplits false}}>All Periods</button>
+              <button class="ui button {{if (not factor.temporalModeSplits) "positive"}}" onClick={{action toggleTemporalModeSplits false}}>All Periods</button>
             </div>
           </td>
         </tr>
@@ -62,7 +62,7 @@
         {{#each activeModes as |mode|}}
           <Transportation::Tdf::ModalSplits::TableRow
             @mode={{mode}}
-            @modeActive=true
+            @modeActive={{true}}
             @addActiveMode={{addActiveMode}}
             @removeActiveMode={{removeActiveMode}}
             
@@ -124,19 +124,19 @@
         <tr>
           <td>
             <div class="ui small buttons">
-              <button class="ui button {{if factor.manualModeSplits 'positive'}}" onClick={{action toggleManualModeSplits}}>Manual</button>
+              <button class="ui button {{if factor.manualModeSplits "positive"}}" onClick={{action toggleManualModeSplits}}>Manual</button>
               <div class="or"></div>
-              <button class="ui button {{if (not factor.manualModeSplits) 'positive'}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
+              <button class="ui button {{if (not factor.manualModeSplits) "positive"}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
             </div>
           </td>
           <td>
             {{!-- Census Tract calculations only product on period --}}
           </td>
-          <td colspan="{{if seeCensusTracts (add analysis.censusTractsSelection.length analysis.requiredCensusTractsSelection.length) 1}}">
+          <td colspan={{if seeCensusTracts (add analysis.censusTractsSelection.length analysis.requiredCensusTractsSelection.length) 1}}>
             <div class="ui small buttons">
-              <button class="ui button {{if (not seeCensusTracts) 'positive'}}" onClick={{action toggleSeeCensusTracts false}}>Map</button>
+              <button class="ui button {{if (not seeCensusTracts) "positive"}}" onClick={{action toggleSeeCensusTracts false}}>Map</button>
               <div class="or"></div>
-              <button class="ui button {{if seeCensusTracts 'positive'}}" onClick={{action toggleSeeCensusTracts true}}>Table</button>
+              <button class="ui button {{if seeCensusTracts "positive"}}" onClick={{action toggleSeeCensusTracts true}}>Table</button>
             </div>
             
             <Analysis::DataPackageSelector
@@ -199,7 +199,7 @@
         {{#each activeModes as |mode idx|}}
           <Transportation::Tdf::ModalSplits::TableRow
             @mode={{mode}}
-            @modeActive=true
+            @modeActive={{true}}
             @addActiveMode={{addActiveMode}}
             @removeActiveMode={{removeActiveMode}}
             
@@ -210,7 +210,7 @@
             @editModes={{editModes}}
           >
             {{#if (eq idx 0)}}
-              <td rowspan={{add activeModes.length 1}} style="{{if seeCensusTracts "display:none;"}}">
+              <td rowspan={{add activeModes.length 1}} style={{if seeCensusTracts "display:none;" ""}}>
                 <Transportation::Tdf::ModalSplits::CensusTractsMap 
                   @analysis={{analysis}}
                   @project={{project}}
@@ -274,7 +274,7 @@
               @factor={{factor}}
             />
           </td>
-          <td colspan="{{if seeCensusTracts (add analysis.censusTractsSelection.length analysis.requiredCensusTractsSelection.length) 1}}"></td>
+          <td colspan={{if seeCensusTracts (add analysis.censusTractsSelection.length analysis.requiredCensusTractsSelection.length) 1}}></td>
         </tr>
       </tbody>
     </table>

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map.hbs
@@ -13,7 +13,7 @@
   />
 
   <MapboxGlSource
-    @sourceId='bbls_geojson'
+    @sourceId="bbls_geojson"
     @map={{map.instance}}
     @options={{hash type="geojson" data=project.bblsGeojson}} as |source|
   >
@@ -21,29 +21,29 @@
       @layer={{hash
         id="bbls"
         type="line"
-        paint=(get-layer-style 'bbls' 'paint')
+        paint=(get-layer-style "bbls" "paint")
       }}
     />
   </MapboxGlSource>
 
   <Mapbox::CartoVectorSource @sourceId="carto" @map={{map}} as |carto-source|>
     <carto-source.layer
-      @id='transit-zones-fill'
-      @sql='SELECT * from ceqr_data_traffic_zones_2019'
+      @id="transit-zones-fill"
+      @sql="SELECT * from ceqr_data_traffic_zones_2019"
       @layer={{hash
-        type='fill'
-        layout=(hash visibility=(if this.showTransitZones 'visible' 'none'))
-        paint=(get-layer-style 'transit-zones-fill' 'paint')
+        type="fill"
+        layout=(hash visibility=(if this.showTransitZones "visible" "none"))
+        paint=(get-layer-style "transit-zones-fill" "paint")
       }}
     />
 
     <carto-source.layer
-      @id='land-use'
-      @sql='SELECT the_geom, the_geom_webmercator, landuse FROM mappluto'
+      @id="land-use"
+      @sql="SELECT the_geom, the_geom_webmercator, landuse FROM mappluto"
       @layer={{hash
-        type='fill'
-        layout=(hash visibility=(if this.showLandUse 'visible' 'none'))
-        paint=(get-layer-style 'land-use' 'paint')
+        type="fill"
+        layout=(hash visibility=(if this.showLandUse "visible" "none"))
+        paint=(get-layer-style "land-use" "paint")
       }}
     />
 
@@ -53,7 +53,7 @@
       @sql="select * from mta_subway_routes_v0"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'subway-routes' 'paint')
+        paint=(get-layer-style "subway-routes" "paint")
       }}
      />
 
@@ -62,7 +62,7 @@
       @sql="select * from mta_subway_stops_v0"
       @layer={{hash
         type="circle"
-        paint=(get-layer-style 'subway-stops' 'paint')
+        paint=(get-layer-style "subway-stops" "paint")
       }}
      />
     <carto-source.layer
@@ -70,24 +70,14 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-content' 'paint')
+        paint=(get-layer-style "selectable-feature-content" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureHoverer
         @map={{map}}
         @layerId={{layer.layerId}}
         @onFeatures={{setFirstHoveredFeatureId}}
-        as |hoverer|
-      >
-        {{!-- {{#if (and hoverer.point hoverer.features)}}
-          <HoverCard @point={{hoverer.point}}>
-            <Transportation::Tdf::ModalSplits::CensusTractsMap::CensusTractPopup
-              @feature={{hoverer.features.firstObject}}
-              data-test-popup='census-tract'
-            />
-          </HoverCard>
-        {{/if}} --}}
-      </Mapbox::FeatureHoverer>
+      />
 
       <Mapbox::FeatureSelector
         @map={{map}}
@@ -106,8 +96,8 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-line' 'paint')
-        layout=(get-layer-style 'selectable-feature-line' 'layout')
+        paint=(get-layer-style "selectable-feature-line" "paint")
+        layout=(get-layer-style "selectable-feature-line" "layout")
       }}
     />
 
@@ -117,8 +107,8 @@
       @layer={{hash
         type="symbol"
         minzoom=11
-        paint=(get-layer-style 'selectable-feature-label' 'paint')
-        layout=(get-layer-style 'selectable-feature-label' 'layout')
+        paint=(get-layer-style "selectable-feature-label" "paint")
+        layout=(get-layer-style "selectable-feature-label" "layout")
       }}
     />
 
@@ -127,7 +117,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-hover' 'paint')
+        paint=(get-layer-style "selectable-feature-hover" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -143,7 +133,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-selected-fill-bold' 'paint')
+        paint=(get-layer-style "selectable-feature-selected-fill-bold" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -159,7 +149,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-selected-fill-light' 'paint')
+        paint=(get-layer-style "selectable-feature-selected-fill-light" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -175,8 +165,8 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-selected-line' 'paint')
-        layout=(get-layer-style 'selectable-feature-selected-line' 'layout')
+        paint=(get-layer-style "selectable-feature-selected-line" "paint")
+        layout=(get-layer-style "selectable-feature-selected-line" "layout")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map/census-tract-popup/modal-split-formatter.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map/census-tract-popup/modal-split-formatter.hbs
@@ -1,4 +1,4 @@
-<table class='ui celled structured unstackable table'>
+<table class="ui celled structured unstackable table">
   <thead>
     <tr>
       <th></th>
@@ -24,7 +24,7 @@
   <tbody>
     {{#each this.displayVariables as |variable|}}
       <tr>
-       <td data-test-mode={{variable}}>{{get (get acsData variable) 'mode'}}</td>
+       <td data-test-mode={{variable}}>{{get (get acsData variable) "mode"}}</td>
        <td class="single line" data-test-acs-value={{variable}}>
          {{get-split-value acsData variable}}<span class="moe"> {{get-split-moe acsData variable}}</span>
        </td>

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map/features.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/census-tracts-map/features.hbs
@@ -17,37 +17,37 @@
 
 <div class="map-legend">
   <div class="ui list">
-    {{#let (get-layer-colors 'project-bbls') as |projectBblsColors|}}
+    {{#let (get-layer-colors "project-bbls") as |projectBblsColors|}}
     <div data-test-default-legend-item class="item">
-      <i class="square outline icon" style={{get-color-style (get projectBblsColors 'line')}}></i>
+      <i class="square outline icon" style={{get-color-style (get projectBblsColors "line")}}></i>
       <div class="content">Project BBLs</div>
     </div>
     {{/let}}
-    {{#let (get-layer-colors 'selectable-features') as |selectableFeatureColors|}}
+    {{#let (get-layer-colors "selectable-features") as |selectableFeatureColors|}}
     <div data-test-default-legend-item class="item">
-      <i class="square icon" style={{get-color-style (get selectableFeatureColors 'selected-fill-light')}}></i>
+      <i class="square icon" style={{get-color-style (get selectableFeatureColors "selected-fill-light")}}></i>
       <div class="content">Selected Census Tracts</div>
     </div>
     <div data-test-default-legend-item class="item">
-      <i class="square icon" style={{get-color-style (get selectableFeatureColors 'selected-fill-bold')}}></i>
+      <i class="square icon" style={{get-color-style (get selectableFeatureColors "selected-fill-bold")}}></i>
       <div class="content">Required Census Tracts</div>
     </div>
     {{/let}}
     {{#if showTransitZones}}
       <div class="ui divider" style="margin: 0.5rem 0rem"></div>
-      {{#each (get-layer-category-colors 'transit-zone') as |categoryColor|}}
+      {{#each (get-layer-category-colors "transit-zone") as |categoryColor|}}
         <div data-test-tz-legend-item class="item">
-          <i class="square icon" style={{get-color-style (get categoryColor 'color')}}></i>
-          <div class="content">Transit Zone {{get categoryColor 'category'}}</div>
+          <i class="square icon" style={{get-color-style (get categoryColor "color")}}></i>
+          <div class="content">Transit Zone {{get categoryColor "category"}}</div>
         </div>
       {{/each}}
     {{/if}}
     {{#if showLandUse}}
       <div class="ui divider" style="margin: 0.5rem 0rem"></div>
-      {{#each (get-layer-category-colors 'land-use') as |categoryColor|}}
+      {{#each (get-layer-category-colors "land-use") as |categoryColor|}}
         <div data-test-lu-legend-item class="item">
-          <i class="square icon" style={{get-color-style (get categoryColor 'color')}}></i>
-          <div class="content">{{get landUseDescriptionsLookup (get categoryColor 'category')}}</div>
+          <i class="square icon" style={{get-color-style (get categoryColor "color")}}></i>
+          <div class="content">{{get landUseDescriptionsLookup (get categoryColor "category")}}</div>
         </div>
       {{/each}}
     {{/if}}

--- a/frontend/app/templates/components/transportation/tdf/trip-results/vehicle-trips.hbs
+++ b/frontend/app/templates/components/transportation/tdf/trip-results/vehicle-trips.hbs
@@ -19,7 +19,7 @@
     </thead>
     <tbody>
       {{#each rows as |row|}}
-        {{#if (and (eq row.mode 'taxi') balancedTaxi)}}
+        {{#if (and (eq row.mode "taxi") balancedTaxi)}}
           <tr>
             <td>
               {{mode-label row.mode}} 
@@ -29,7 +29,7 @@
             <td>{{row.out}}</td>
             <td>{{row.total}}</td>
           </tr>
-        {{else if (and (eq row.mode 'taxi') (not balancedTaxi))}}
+        {{else if (and (eq row.mode "taxi") (not balancedTaxi))}}
           <tr>
             <td>
               {{mode-label row.mode}} 

--- a/frontend/app/templates/components/transportation/tdf/vehicle-occupancy.hbs
+++ b/frontend/app/templates/components/transportation/tdf/vehicle-occupancy.hbs
@@ -9,9 +9,9 @@
         <td class="six wide"></td>
         <td class="three wide" colspan={{if factor.temporalVehicleOccupancy "4" "1"}}>
           <div class="ui small buttons">
-            <button class="ui button {{if factor.temporalVehicleOccupancy 'positive'}}" onClick={{action toggleTemporalVehicleOccupancy true}}>Temporal Splits</button>
+            <button class="ui button {{if factor.temporalVehicleOccupancy "positive"}}" onClick={{action toggleTemporalVehicleOccupancy true}}>Temporal Splits</button>
             <div class="or"></div>
-            <button class="ui button {{if (not factor.temporalVehicleOccupancy) 'positive'}}" onClick={{action toggleTemporalVehicleOccupancy false}}>All Periods</button>
+            <button class="ui button {{if (not factor.temporalVehicleOccupancy) "positive"}}" onClick={{action toggleTemporalVehicleOccupancy false}}>All Periods</button>
           </div>
         </td>
       </tr>
@@ -38,7 +38,7 @@
     <tbody class="ui form">
       <tr>
         <td>
-          {{mode-label 'auto'}}
+          {{mode-label "auto"}}
           {{#if (not factor.manualModeSplits)}}
             <UiPopup style="float: right;" @content="Average calculated using selected Census Tracts">
               <div class="ui basic blue horizontal label">
@@ -60,7 +60,7 @@
         {{/if}}
       </tr>
       <tr>
-        <td>{{mode-label 'taxi'}}</td>
+        <td>{{mode-label "taxi"}}</td>
 
         {{#if factor.temporalVehicleOccupancy}}
           <td>{{input type="number" step=".01" min="0" value=vehicleOccupancy.taxi.am}}</td>

--- a/frontend/app/templates/components/transportation/trip-generation-map.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-map.hbs
@@ -8,7 +8,7 @@
   }} as |map|
 >
   <MapboxGlSource
-    @sourceId='bbls_geojson'
+    @sourceId="bbls_geojson"
     @map={{map.instance}}
     @options={{hash type="geojson" data=project.bblsGeojson}} as |source|
   >
@@ -16,7 +16,7 @@
       @layer={{hash
         id="bbls"
         type="line"
-        paint=(get-layer-style 'bbls' 'paint')
+        paint=(get-layer-style "bbls" "paint")
       }}
     />
   </MapboxGlSource>
@@ -28,7 +28,7 @@
       @sql="select * from mta_subway_routes_v0"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'subway-routes' 'paint')
+        paint=(get-layer-style "subway-routes" "paint")
       }}
      />
 
@@ -37,7 +37,7 @@
       @sql="select * from mta_subway_stops_v0"
       @layer={{hash
         type="circle"
-        paint=(get-layer-style 'subway-stops' 'paint')
+        paint=(get-layer-style "subway-stops" "paint")
       }}
      />
     <carto-source.layer
@@ -45,7 +45,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-content' 'paint')
+        paint=(get-layer-style "selectable-feature-content" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureHoverer
@@ -58,7 +58,7 @@
           <HoverCard @point={{hoverer.point}}>
             <Transportation::CensusTractsMap::CensusTractPopup
               @feature={{hoverer.features.firstObject}}
-              data-test-popup='census-tract'
+              data-test-popup="census-tract"
             />
           </HoverCard>
         {{/if}}
@@ -70,8 +70,8 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-line' 'paint')
-        layout=(get-layer-style 'selectable-feature-line' 'layout')
+        paint=(get-layer-style "selectable-feature-line" "paint")
+        layout=(get-layer-style "selectable-feature-line" "layout")
       }}
     />
 
@@ -80,7 +80,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-hover' 'paint')
+        paint=(get-layer-style "selectable-feature-hover" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -96,7 +96,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-selected-fill-bold' 'paint')
+        paint=(get-layer-style "selectable-feature-selected-fill-bold" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -112,7 +112,7 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="fill"
-        paint=(get-layer-style 'selectable-feature-selected-fill-light' 'paint')
+        paint=(get-layer-style "selectable-feature-selected-fill-light" "paint")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer
@@ -128,8 +128,8 @@
       @sql="select * from nyc_census_tracts_2010"
       @layer={{hash
         type="line"
-        paint=(get-layer-style 'selectable-feature-selected-line' 'paint')
-        layout=(get-layer-style 'selectable-feature-selected-line' 'layout')
+        paint=(get-layer-style "selectable-feature-selected-line" "paint")
+        layout=(get-layer-style "selectable-feature-selected-line" "layout")
       }} as |layer|
     >
       <Mapbox::FeatureFilterer

--- a/frontend/app/templates/components/transportation/trip-generation-tables/trip-generation-results.hbs
+++ b/frontend/app/templates/components/transportation/trip-generation-tables/trip-generation-results.hbs
@@ -50,141 +50,130 @@
     <tbody>
       {{#if (await this.selectedCensusTractData)}}
         {{#each-in this.analysis.temporalDistributions as |time timeInfo|}}
-          {{#each (array (hash key='in' label="In") (hash key='out' label="Out") (hash key='total' label="Total")) as |inOutOrTotal idx|}}
+          {{#each (array (hash key="in" label="In") (hash key="out" label="Out") (hash key="total" label="Total")) as |inOutOrTotal idx|}}
             <tr>
               {{#if (is-equal idx 0)}}
                 <td rowspan="3">{{timeInfo.label}}</td>
               {{/if}}
               <td>{{inOutOrTotal.label}}</td>
-              {{#with (hash
-                  trans_auto_total=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_auto_total') false) 100)
-                  trans_taxi=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_taxi') false) 100)
-                  trans_public_bus=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_public_bus') false) 100)
-                  trans_public_subway=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_public_subway') false) 100)
-                  trans_walk=(div (get-aggregate-percent this.selectedCensusTractData (array 'trans_walk') false) 100)
-                  vehicle_occupancy=(get-aggregate-value this.selectedCensusTractData (array 'vehicle_occupancy'))
-              ) as |modeAggPcts|}}
-                {{#with this.analysis as |ta|}}
-                  {{#with (div (get (get ta.temporalDistributions time) 'percent') 100) as |temporalDistPct|}}
-                    {{#if (and (not-eq time "saturday") (not-eq inOutOrTotal.key "total"))}}
-                      {{#each this.modalSplitVariablesSubset as |mode|}}
-                        <td>
-                          {{round (get (get (get this.weekdayModeCalcs time) inOutOrTotal.key) mode)}}
-                        </td>
-                      {{/each}}
-                      <td>
-                        {{round (get (get this.weekdayModesTotals time) inOutOrTotal.key)}}
-                      </td>
-                      <td>
-                        {{round (get (get this.weekdayAutoVehicleTripCalcs time) inOutOrTotal.key)}}
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round (get (get this.weekdayTaxiVehicleTripCalcs time) inOutOrTotal.key)}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
-                      <td>
-                        -
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round (get (get weekdayVehicleTripTotals time) inOutOrTotal.key)}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
-                    {{else if (not-eq time "saturday")}}
-                      {{#each this.modalSplitVariablesSubset as |mode|}}
-                        <td>
-                          {{round (get (get this.totalsOfWeekdayMode time) mode)}}
-                        </td>
-                      {{/each}}
-                      <td>
-                        {{round (get this.totalsOfTotalsOfWeekdayMode time)}}
-                      </td>
-                      <td>
-                        {{round (get this.totalsOfWeekdayAutoVehicleTrip time)}}
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round (get this.totalsOfWeekdayTaxiVehicleTrip time)}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
-                      <td>
-                        -
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round (get this.totalsOfTotalsOfWeekdayVehicleTrip time)}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
-                    {{else if (not-eq inOutOrTotal.key "total")}}
-                      {{#each this.modalSplitVariablesSubset as |mode|}}
-                        <td>
-                          {{round (get (get this.saturdayModeCalcs inOutOrTotal.key) mode)}}
-                        </td>
-                      {{/each}}
-                      <td>
-                        {{round (get this.saturdayModesTotals inOutOrTotal.key)}}
-                      </td>
-                      <td>
-                        {{round (get this.saturdayAutoVehicleTripCalcs inOutOrTotal.key)}}
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round (get this.saturdayTaxiVehicleTripCalcs inOutOrTotal.key)}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
-                      <td>
-                        -
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round (get this.saturdayVehicleTripTotals inOutOrTotal.key)}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
+              {{#with this.analysis as |ta|}}
+                {{#if (and (not-eq time "saturday") (not-eq inOutOrTotal.key "total"))}}
+                  {{#each this.modalSplitVariablesSubset as |mode|}}
+                    <td>
+                      {{round (get (get (get this.weekdayModeCalcs time) inOutOrTotal.key) mode)}}
+                    </td>
+                  {{/each}}
+                  <td>
+                    {{round (get (get this.weekdayModesTotals time) inOutOrTotal.key)}}
+                  </td>
+                  <td>
+                    {{round (get (get this.weekdayAutoVehicleTripCalcs time) inOutOrTotal.key)}}
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round (get (get this.weekdayTaxiVehicleTripCalcs time) inOutOrTotal.key)}}
                     {{else}}
-                      {{#each this.modalSplitVariablesSubset as |mode|}}
-                        <td>
-                          {{round (get this.totalsOfSaturdayMode mode)}}
-                        </td>
-                      {{/each}}
-                      <td>
-                        {{round this.totalOfTotalsOfSaturdayMode}}
-                      </td>
-                      <td>
-                        {{round this.totalOfSaturdayAutoVehicleTrip}}
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round this.totalOfSaturdayTaxiVehicleTrip}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
-                      <td>
-                        -
-                      </td>
-                      <td>
-                        {{#if ta.taxiVehicleOccupancy}}
-                          {{round this.totalOfTotalsOfSaturdayVehicleTrip}}
-                        {{else}}
-                          -
-                        {{/if}}
-                      </td>
+                      -
                     {{/if}}
-                  {{/with}}
-                {{/with}}
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round (get (get weekdayVehicleTripTotals time) inOutOrTotal.key)}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                {{else if (not-eq time "saturday")}}
+                  {{#each this.modalSplitVariablesSubset as |mode|}}
+                    <td>
+                      {{round (get (get this.totalsOfWeekdayMode time) mode)}}
+                    </td>
+                  {{/each}}
+                  <td>
+                    {{round (get this.totalsOfTotalsOfWeekdayMode time)}}
+                  </td>
+                  <td>
+                    {{round (get this.totalsOfWeekdayAutoVehicleTrip time)}}
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round (get this.totalsOfWeekdayTaxiVehicleTrip time)}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round (get this.totalsOfTotalsOfWeekdayVehicleTrip time)}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                {{else if (not-eq inOutOrTotal.key "total")}}
+                  {{#each this.modalSplitVariablesSubset as |mode|}}
+                    <td>
+                      {{round (get (get this.saturdayModeCalcs inOutOrTotal.key) mode)}}
+                    </td>
+                  {{/each}}
+                  <td>
+                    {{round (get this.saturdayModesTotals inOutOrTotal.key)}}
+                  </td>
+                  <td>
+                    {{round (get this.saturdayAutoVehicleTripCalcs inOutOrTotal.key)}}
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round (get this.saturdayTaxiVehicleTripCalcs inOutOrTotal.key)}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round (get this.saturdayVehicleTripTotals inOutOrTotal.key)}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                {{else}}
+                  {{#each this.modalSplitVariablesSubset as |mode|}}
+                    <td>
+                      {{round (get this.totalsOfSaturdayMode mode)}}
+                    </td>
+                  {{/each}}
+                  <td>
+                    {{round this.totalOfTotalsOfSaturdayMode}}
+                  </td>
+                  <td>
+                    {{round this.totalOfSaturdayAutoVehicleTrip}}
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round this.totalOfSaturdayTaxiVehicleTrip}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                  <td>
+                    -
+                  </td>
+                  <td>
+                    {{#if ta.taxiVehicleOccupancy}}
+                      {{round this.totalOfTotalsOfSaturdayVehicleTrip}}
+                    {{else}}
+                      -
+                    {{/if}}
+                  </td>
+                {{/if}}
               {{/with}}
             </tr>
           {{/each}}

--- a/frontend/app/templates/signup/email.hbs
+++ b/frontend/app/templates/signup/email.hbs
@@ -7,7 +7,7 @@
     </h2>
     <p>
       We've sent a confirmation email to your account.
-      <br />
+      <br>
       Find it and click through to confirm your email address.
     </p>
     <p>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^2.0.0",
+    "ember-cli-template-lint": "^1.0.0",
     "ember-cli-uglify": "^2.1.0",
     "ember-cli-update": "^0.30.0",
     "ember-composable-helpers": "^2.1.0",


### PR DESCRIPTION
This PR fixes all template linting errors, then introduces template linting tests simply by installing `ember-cli-template-lint`. The addon automatically adds template linting tests to ember's test suite.  

Template lint rules are defined in `.template-lintrc.js`. The project already had some custom rules in it:
```
  rules: {
    'attribute-indentation': false,
    'block-indentation': false,

    // Should probably apply these eventually
    'no-invalid-interactive': false,
    'no-inline-styles': false
  }
```

A subsequent PR could remove these rules and fix up consequent linting errors, if desired. 