### PR TITLE
Change computed property to a getter

### DIFF
--- a/frontend/app/controllers/project/show/public-schools.js
+++ b/frontend/app/controllers/project/show/public-schools.js
@@ -11,7 +11,7 @@ export default class ProjectShowPublicSchoolsController extends Controller {
   @alias('model.publicSchoolsAnalysis') analysis;
 
   @computed('router.currentRouteName')
-  showMap() {
+  get showMap() {
     const current = this.get('router.currentRouteName');
     return (current.includes('existing-conditions') || current.includes('no-action'));
   }


### PR DESCRIPTION
Computed property decorators must decorate native getters/setters, not methods. This change converts showMap to a getter, eliminating warning-level “error” in the test suite.