### PR TITLE
Removes unused ember-ast-hot-load configuration

### DIFF
--- a/frontend/ember-cli-build.js
+++ b/frontend/ember-cli-build.js
@@ -32,24 +32,6 @@ module.exports = function(defaults) {
         semverRange: '*',
       }],
     },
-
-    'ember-ast-hot-load': {
-      helpers: [
-        'page-title',
-        'find-modal-split',
-        'get-aggregate-value',
-        'get-aggregate-percent',
-        'get-split-value',
-        'get-split-percent',
-        'human-readable-census-tract',
-        'map-color-for',
-        'percentage',
-        'school-year',
-        'mode-label',
-        'humanize-geoid',
-      ],
-      enabled: true,
-    },
   });
 
   app.import('node_modules/@sentry/browser/dist/index.js', {


### PR DESCRIPTION
ember-ast-hot-load was removed so this configuration doesn’t need to be in here