### PR TITLE
564: integration test for components/transportation/tdf/modal-splits.js

### DIFF
--- a/frontend/app/components/transportation/tdf/modal-splits.js
+++ b/frontend/app/components/transportation/tdf/modal-splits.js
@@ -26,6 +26,9 @@ export default class TransportationTdfModalSplitsComponent extends Component {
     'modeSplits.{auto,taxi,bus,subway,railroad,walk,ferry,streetcar,bicycle,motorcycle,other}.{allPeriods,am,pm,md,saturday}',
   )
   get total() {
+    // modesForAnalysis = e.g. ['auto', 'taxi', 'bus', 'subway', 'walk', 'railroad']
+    // modeSplits = e.g. { auto: { allPeriods: 10.1, count: 2712 }, taxi: { allPeriods: 3.6, count: 981 } }
+    // reduce function to add up the am/md/pm/saturday/allPeriods values for each mode in the modesForAnalysis array
     return {
       allPeriods: this.factor.modesForAnalysis.reduce((pv, key) => pv + parseFloat(this.modeSplits[key].allPeriods), 0),
       am: this.factor.modesForAnalysis.reduce((pv, key) => pv + parseFloat(this.modeSplits[key].am), 0),

--- a/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map.js
+++ b/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map.js
@@ -70,7 +70,7 @@ export default class TransportationCensusTractsMapComponent extends Component {
 
   @computed('analysis.censusTractsCentroid')
   get censusTractsCentroidLngLat() {
-    return this.analysis.censusTractsCentroid.features.firstObject.geometry.coordinates;
+    return this.analysis.get('censusTractsCentroid').features.firstObject.geometry.coordinates;
   }
 
   /**

--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -22,7 +22,13 @@
             <div class="ui small buttons">
               <button class="ui button {{if factor.temporalModeSplits "positive"}}" onClick={{action toggleTemporalModeSplits true}}>Temporal Splits</button>
               <div class="or"></div>
-              <button class="ui button {{if (not factor.temporalModeSplits) "positive"}}" onClick={{action toggleTemporalModeSplits false}}>All Periods</button>
+              <button
+                class="ui button {{if (not factor.temporalModeSplits) "positive"}}"
+                onClick={{action toggleTemporalModeSplits false}}
+                data-test-button="all periods toggle"
+                >
+                All Periods
+              </button>
             </div>
           </td>
         </tr>
@@ -65,9 +71,9 @@
             @modeActive={{true}}
             @addActiveMode={{addActiveMode}}
             @removeActiveMode={{removeActiveMode}}
-            
+
             @modeSplits={{modeSplits}}
-            
+
             @showInput={{manualModeSplits}}
             @showTemporalModeSplits={{factor.temporalModeSplits}}
             @editModes={{editModes}}
@@ -75,31 +81,31 @@
         {{/each}}
 
         <tr class="warning">
-          <td><strong>TOTAL</strong></td>          
+          <td><strong>TOTAL</strong></td>
           {{#if factor.temporalModeSplits}}
-            <td>{{total.am}}</td>
-            <td>{{total.md}}</td>
-            <td>{{total.pm}}</td>
-            <td>{{total.saturday}}</td>
+            <td data-test-total-am>{{total.am}}</td>
+            <td data-test-total-md>{{total.md}}</td>
+            <td data-test-total-pm>{{total.pm}}</td>
+            <td data-test-total-saturday>{{total.saturday}}</td>
           {{else}}
-            <td>
-              {{total.allPeriods}} % 
+            <td data-test-total-all-periods>
+              {{total.allPeriods}} %
               {{#if (not manualModeSplits)}}
                 ({{total.count}})
               {{/if}}
             </td>
           {{/if}}
         </tr>
-    
+
         {{#if editModes}}
           {{#each inactiveModes as |mode|}}
             <Transportation::Tdf::ModalSplits::TableRow
               @mode={{mode}}
               @addActiveMode={{addActiveMode}}
               @removeActiveMode={{removeActiveMode}}
-              
+
               @modeSplits={{modeSplits}}
-              
+
               @showInput={{manualModeSplits}}
               @showTemporalModeSplits={{factor.temporalModeSplits}}
               @editModes={{editModes}}
@@ -108,7 +114,7 @@
         {{/if}}
         <tr>
           <td colspan={{if factor.temporalModeSplits "5" "2"}}>
-            <Transportation::Tdf::TableNote 
+            <Transportation::Tdf::TableNote
               @tableName="modalSplits"
               @factor={{factor}}
             />
@@ -138,7 +144,7 @@
               <div class="or"></div>
               <button class="ui button {{if seeCensusTracts "positive"}}" onClick={{action toggleSeeCensusTracts true}}>Table</button>
             </div>
-            
+
             <Analysis::DataPackageSelector
               style="display: inline-block;"
               @currentPackage={{factor.dataPackage}}
@@ -202,16 +208,16 @@
             @modeActive={{true}}
             @addActiveMode={{addActiveMode}}
             @removeActiveMode={{removeActiveMode}}
-            
+
             @modeSplits={{modeSplits}}
-            
+
             @showInput={{manualModeSplits}}
             @showTemporalModeSplits={{factor.temporalModeSplits}}
             @editModes={{editModes}}
           >
             {{#if (eq idx 0)}}
               <td rowspan={{add activeModes.length 1}} style={{if seeCensusTracts "display:none;" ""}}>
-                <Transportation::Tdf::ModalSplits::CensusTractsMap 
+                <Transportation::Tdf::ModalSplits::CensusTractsMap
                   @analysis={{analysis}}
                   @project={{project}}
                   @factor={{factor}}
@@ -236,10 +242,10 @@
         <tr class="warning">
           <td><strong>TOTAL</strong></td>
           <td>
-            {{total.allPeriods}} % 
+            {{total.allPeriods}} %
             {{#if (not manualModeSplits)}}
               ({{total.count}})
-            {{/if}}  
+            {{/if}}
           </td>
 
           {{#if seeCensusTracts}}
@@ -251,16 +257,16 @@
             {{/each}}
           {{/if}}
         </tr>
-    
+
         {{#if editModes}}
           {{#each inactiveModes as |mode|}}
             <Transportation::Tdf::ModalSplits::TableRow
               @mode={{mode}}
               @addActiveMode={{addActiveMode}}
               @removeActiveMode={{removeActiveMode}}
-              
+
               @modeSplits={{modeSplits}}
-              
+
               @showInput={{manualModeSplits}}
               @showTemporalModeSplits={{factor.temporalModeSplits}}
               @editModes={{editModes}}
@@ -269,7 +275,7 @@
         {{/if}}
         <tr>
           <td colspan="2">
-            <Transportation::Tdf::TableNote 
+            <Transportation::Tdf::TableNote
               @tableName="modalSplits"
               @factor={{factor}}
             />

--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -15,7 +15,12 @@
             <div class="ui small buttons">
               <button class="ui button {{if factor.manualModeSplits "positive"}}" onClick={{action toggleManualModeSplits}}>Manual</button>
               <div class="or"></div>
-              <button class="ui button {{if (not factor.manualModeSplits) "positive"}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
+              <button
+                class="ui button {{if (not factor.manualModeSplits) "positive"}}"
+                onClick={{action toggleCensusTractModeSplits}}
+                data-test-button="toggle census tract mode splits">
+                Census Tracts
+              </button>
             </div>
           </td>
           <td colspan={{if factor.temporalModeSplits "4" "1"}}>
@@ -130,7 +135,12 @@
         <tr>
           <td>
             <div class="ui small buttons">
-              <button class="ui button {{if factor.manualModeSplits "positive"}}" onClick={{action toggleManualModeSplits}}>Manual</button>
+              <button
+                class="ui button {{if factor.manualModeSplits "positive"}}"
+                onClick={{action toggleManualModeSplits}}
+                data-test-button="toggle manual mode splits">
+                Manual
+              </button>
               <div class="or"></div>
               <button class="ui button {{if (not factor.manualModeSplits) "positive"}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
             </div>
@@ -142,7 +152,7 @@
             <div class="ui small buttons">
               <button class="ui button {{if (not seeCensusTracts) "positive"}}" onClick={{action toggleSeeCensusTracts false}}>Map</button>
               <div class="or"></div>
-              <button class="ui button {{if seeCensusTracts "positive"}}" onClick={{action toggleSeeCensusTracts true}}>Table</button>
+              <button data-test-button="see census tracts" class="ui button {{if seeCensusTracts "positive"}}" onClick={{action toggleSeeCensusTracts true}}>Table</button>
             </div>
 
             <Analysis::DataPackageSelector

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
@@ -5,7 +5,7 @@
       @value={{mode}}
       @onChecked={{action addActiveMode}}
       @onUnchecked={{action removeActiveMode}}
-    />  
+    />
   {{/if}}
 
   {{mode-label mode}}
@@ -15,7 +15,7 @@
   {{#if showTemporalModeSplits}}
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=amPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=amPercent data-test-modal-split-input-am=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -23,7 +23,7 @@
     </td>
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=mdPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=mdPercent data-test-modal-split-input-md=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -31,7 +31,7 @@
     </td>
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=pmPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=pmPercent data-test-modal-split-input-pm=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -39,7 +39,7 @@
     </td>
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=satPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=satPercent data-test-modal-split-input-sat=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -48,15 +48,15 @@
   {{else}}
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=allPeriodPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=allPeriodPercent data-test-modal-split-input-allperiods=mode}}
         <div class="ui basic label">
           %
         </div>
       </div>
     </td>
   {{/if}}
-{{else}}    
-  <td>
+{{else}}
+  <td data-test-all-periods={{mode}}>
     {{allPeriodPercent}} % ({{count}})
   </td>
 {{/if}}

--- a/frontend/app/utils/censusTractVariableForMode.js
+++ b/frontend/app/utils/censusTractVariableForMode.js
@@ -12,6 +12,8 @@ export const MODES = [
   'other',
 ];
 
+// these values, e.g. "trans-auto-total" are sourced from the transportation_planning_factors table
+// under the column census_tract_variables, where they are nested in objects
 export const MODE_VARIABLE_LOOKUP = {
   auto: 'trans_auto_total',
   taxi: 'trans_taxi',

--- a/frontend/mirage/config.js
+++ b/frontend/mirage/config.js
@@ -192,4 +192,6 @@ export default function() {
 
   this.get('transportation-planning-factors');
   this.get('transportation-planning-factors/:id');
+  this.post('transportation-planning-factors');
+  this.patch('transportation-planning-factors/:id');
 }

--- a/frontend/tests/integration/components/transportation/tdf/modal-splits-test.js
+++ b/frontend/tests/integration/components/transportation/tdf/modal-splits-test.js
@@ -1,0 +1,112 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | transportation/tdf/modal-splits', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('calculates manual mode split totals correctly', async function(assert) {
+    const store = this.owner.lookup('service:store');
+
+    this.server.create('user');
+    this.server.create('data-package');
+    this.server.create('project', {
+      publicSchoolsAnalysis: this.server.create('publicSchoolsAnalysis'),
+      transportationAnalysis: this.server.create('transportationAnalysis', {
+        transportationPlanningFactors: [
+          this.server.create('transportationPlanningFactor', {
+            dataPackage: this.server.create('dataPackage', 'nycAcs'),
+            landUse: 'residential',
+            // necessary for displaying certain elements
+            // am/md/pm/saturday values (true) vs. allPeriods values (false)
+            temporalModeSplits: true,
+            // necessary for displaying certain elements
+            // user input mode splits (true) vs. mode split values from census tract calculator (false)
+            manualModeSplits: true,
+          }),
+        ],
+      }),
+    });
+
+    // define project model
+    const project = await store.findRecord('project', 1, {
+      include: ['transportation-analysis,transportation-analysis.transportation-planning-factors'].join(','),
+    });
+
+    // replicating how availablePackages is defined on routes/project/show/transportation/tdf/planning-factors/show.js
+    const dataPackage = project.transportationAnalysis.get('transportationPlanningFactors').firstObject.get('dataPackage');
+    const availablePackages = await store.query('data-package', {
+      filter: {
+        package: dataPackage.get('package'),
+      },
+    });
+
+    this.set('transportationPlanningFactorResidentialModel', project.transportationAnalysis.get('transportationPlanningFactors').firstObject);
+    this.set('projectModel', project);
+    this.set('transportationAnalysisModel', project.transportationAnalysis);
+    this.set('availablePackages', availablePackages);
+
+    await render(hbs`
+      {{#transportation/tdf/modal-splits
+        project=project
+        analysis=transportationAnalysisModel
+        factor=transportationPlanningFactorResidentialModel
+        availablePackages=availablePackages}}
+      {{/transportation/tdf/modal-splits}}
+  `);
+
+    // ##### WHEN temporalModeSplits is TRUE ##########################################################
+    // if manualModeSplits is true, then modeSplits = modeSplitsFromUser, which are all default 0
+    assert.equal(this.element.querySelector('[data-test-total-am]').textContent, '0', 'total am default');
+    assert.equal(this.element.querySelector('[data-test-total-md]').textContent, '0', 'total md default');
+    assert.equal(this.element.querySelector('[data-test-total-pm]').textContent, '0', 'total pm default');
+    assert.equal(this.element.querySelector('[data-test-total-saturday]').textContent, '0', 'total saturday default');
+
+    // USER FILLS IN MANUAL MODE SPLITS
+    // total for am should be 3
+    await fillIn('[data-test-modal-split-input-am="auto"]', 1);
+    await fillIn('[data-test-modal-split-input-am="taxi"]', 2);
+
+    // total for md should be 7
+    await fillIn('[data-test-modal-split-input-md="bus"]', 3);
+    await fillIn('[data-test-modal-split-input-md="subway"]', 4);
+
+    // total for pm should be 11
+    await fillIn('[data-test-modal-split-input-pm="railroad"]', 5);
+    await fillIn('[data-test-modal-split-input-pm="auto"]', 6);
+
+    // total for sat should be 15
+    await fillIn('[data-test-modal-split-input-sat="taxi"]', 7);
+    await fillIn('[data-test-modal-split-input-sat="bus"]', 8);
+
+    // tests for total.am, total.md, total.pm, total.saturday in computed property `total`
+    assert.equal(this.element.querySelector('[data-test-total-am]').textContent, '3', 'total am calculated');
+    assert.equal(this.element.querySelector('[data-test-total-md]').textContent, '7', 'total md calculated');
+    assert.equal(this.element.querySelector('[data-test-total-pm]').textContent, '11', 'total pm calculated');
+    assert.equal(this.element.querySelector('[data-test-total-saturday]').textContent, '15', 'total saturday calculated');
+
+    // ##### WHEN temporalModeSplits is FALSE ##########################################################
+    // NOTE: clicking this button also tests the `toggleTemporalModeSplits` action
+    // this action sets temporalModeSplits to false
+    // switches from Temporal Splits tab to All Periods tab
+    await click('[data-test-button="all periods toggle"]');
+
+    // if manualModeSplits is true, then modeSplits = modeSplitsFromUser, which are all default 0
+    assert.ok(this.element.querySelector('[data-test-total-all-periods]').textContent.includes('0'), 'total all periods default');
+
+    // USER FILLS IN MANUAL MODE SPLITS
+    // total for all periods should be 21
+    await fillIn('[data-test-modal-split-input-allperiods="auto"]', 1);
+    await fillIn('[data-test-modal-split-input-allperiods="taxi"]', 2);
+    await fillIn('[data-test-modal-split-input-allperiods="bus"]', 3);
+    await fillIn('[data-test-modal-split-input-allperiods="subway"]', 4);
+    await fillIn('[data-test-modal-split-input-allperiods="railroad"]', 5);
+    await fillIn('[data-test-modal-split-input-allperiods="walk"]', 6);
+
+    // tests for total.allPeriods in computed property `total`
+    assert.ok(this.element.querySelector('[data-test-total-all-periods]').textContent.includes('21'), 'total all periods calculated');
+  });
+});

--- a/frontend/tests/integration/components/transportation/threshold-calculation-test.js
+++ b/frontend/tests/integration/components/transportation/threshold-calculation-test.js
@@ -62,7 +62,7 @@ module('Integration | Component | transportation/threshold-calculation', functio
     }),
   };
 
-  test('it renders', async function(assert) {
+  test('threshold-calculation computed properties calculate correctly', async function(assert) {
     const analysisMirage = server.create('transportation-analysis', projectWithAllLandUses);
 
     const project = await this.owner.lookup('service:store').findRecord(


### PR DESCRIPTION
Addresses #564 

Part of broader issue #557 

Increase code coverage for computed property `total` and action `toggleTemporalModeSplits`
https://codecov.io/gh/NYCPlanning/ceqr-app/src/564-modal-splits-integration-test/frontend/app/components/transportation/tdf/modal-splits.js

Still dealing with lots of whitespace changes, if anyone has any suggestions on how to get rid of that let me know!