### PR TITLE
564: set up integration test for transportation/tdf/modal-splits

### DIFF
--- a/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map.js
+++ b/frontend/app/components/transportation/tdf/modal-splits/census-tracts-map.js
@@ -70,7 +70,7 @@ export default class TransportationCensusTractsMapComponent extends Component {
 
   @computed('analysis.censusTractsCentroid')
   get censusTractsCentroidLngLat() {
-    return this.analysis.censusTractsCentroid.features.firstObject.geometry.coordinates;
+    return this.analysis.get('censusTractsCentroid').features.firstObject.geometry.coordinates;
   }
 
   /**

--- a/frontend/mirage/config.js
+++ b/frontend/mirage/config.js
@@ -192,4 +192,6 @@ export default function() {
 
   this.get('transportation-planning-factors');
   this.get('transportation-planning-factors/:id');
+  this.post('transportation-planning-factors');
+  this.patch('transportation-planning-factors/:id');
 }

--- a/frontend/tests/integration/components/transportation/tdf/modal-splits-test.js
+++ b/frontend/tests/integration/components/transportation/tdf/modal-splits-test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | transportation/tdf/modal-splits', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('temporal split totals calculate correctly when user manually inputs mode split values', async function(assert) {
+    const store = this.owner.lookup('service:store');
+
+    this.server.create('user');
+    this.server.create('data-package');
+    this.server.create('project', {
+      publicSchoolsAnalysis: this.server.create('publicSchoolsAnalysis'),
+      transportationAnalysis: this.server.create('transportationAnalysis', {
+        transportationPlanningFactors: [
+          this.server.create('transportationPlanningFactor', {
+            dataPackage: this.server.create('dataPackage', 'nycAcs'),
+            landUse: 'residential',
+            // necessary for displaying certain elements
+            // am/md/pm/saturday values (true) vs. allPeriods values (false)
+            temporalModeSplits: true,
+            // necessary for displaying certain elements
+            // user input mode splits (true) vs. mode split values from census tract calculator (false)
+            manualModeSplits: true,
+          }),
+        ],
+      }),
+    });
+
+    // define project model
+    const project = await store.findRecord('project', 1, {
+      include: ['transportation-analysis,transportation-analysis.transportation-planning-factors'].join(','),
+    });
+
+    // replicating how availablePackages is defined on routes/project/show/transportation/tdf/planning-factors/show.js
+    const dataPackage = project.transportationAnalysis.get('transportationPlanningFactors').firstObject.get('dataPackage');
+    const availablePackages = await store.query('data-package', {
+      filter: {
+        package: dataPackage.get('package'),
+      },
+    });
+
+    this.project = project;
+    this.transportationPlanningFactorsResidentialModel = project.transportationAnalysis.get('transportationPlanningFactors').firstObject;
+    this.availablePackages = availablePackages;
+
+    await render(hbs`
+      {{#transportation/tdf/modal-splits
+        project=project
+        analysis=project.transportationAnalysis
+        factor=transportationPlanningFactorsResidentialModel
+        availablePackages=availablePackages}}
+      {{/transportation/tdf/modal-splits}}
+    `);
+
+    assert.ok(this.element);
+  });
+});


### PR DESCRIPTION
This PR builds the basic setup for the integration test for components/transportation/tdf/modal-splits.js.

Further PRs will test specific user interactions. 

Addresses #564 

Part of broader testing issue #557 