### PR TITLE
564: add test for user manual input of temporal mode split values

### DIFF
--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -77,10 +77,10 @@
         <tr class="warning">
           <td><strong>TOTAL</strong></td>          
           {{#if factor.temporalModeSplits}}
-            <td>{{total.am}}</td>
-            <td>{{total.md}}</td>
-            <td>{{total.pm}}</td>
-            <td>{{total.saturday}}</td>
+            <td data-test-total-am>{{total.am}}</td>
+            <td data-test-total-md>{{total.md}}</td>
+            <td data-test-total-pm>{{total.pm}}</td>
+            <td data-test-total-saturday>{{total.saturday}}</td>
           {{else}}
             <td>
               {{total.allPeriods}} % 

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
@@ -15,7 +15,7 @@
   {{#if showTemporalModeSplits}}
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=amPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=amPercent data-test-modal-split-input-am=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -23,7 +23,7 @@
     </td>
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=mdPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=mdPercent data-test-modal-split-input-md=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -31,7 +31,7 @@
     </td>
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=pmPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=pmPercent data-test-modal-split-input-pm=mode}}
         <div class="ui basic label">
           %
         </div>
@@ -39,7 +39,7 @@
     </td>
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=satPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=satPercent data-test-modal-split-input-saturday=mode}}
         <div class="ui basic label">
           %
         </div>

--- a/frontend/tests/integration/components/transportation/tdf/modal-splits-test.js
+++ b/frontend/tests/integration/components/transportation/tdf/modal-splits-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -57,6 +57,33 @@ module('Integration | Component | transportation/tdf/modal-splits', function(hoo
       {{/transportation/tdf/modal-splits}}
     `);
 
-    assert.ok(this.element);
+    // if manualModeSplits is true, then modeSplits = modeSplitsFromUser, which are all default 0
+    assert.equal(this.element.querySelector('[data-test-total-am]').textContent, '0', 'total am default');
+    assert.equal(this.element.querySelector('[data-test-total-md]').textContent, '0', 'total md default');
+    assert.equal(this.element.querySelector('[data-test-total-pm]').textContent, '0', 'total pm default');
+    assert.equal(this.element.querySelector('[data-test-total-saturday]').textContent, '0', 'total saturday default');
+
+    // USER FILLS IN MANUAL MODE SPLITS
+    // total for am should be 3
+    await fillIn('[data-test-modal-split-input-am="auto"]', 1);
+    await fillIn('[data-test-modal-split-input-am="taxi"]', 2);
+
+    // total for md should be 7
+    await fillIn('[data-test-modal-split-input-md="bus"]', 3);
+    await fillIn('[data-test-modal-split-input-md="subway"]', 4);
+
+    // total for pm should be 11
+    await fillIn('[data-test-modal-split-input-pm="railroad"]', 5);
+    await fillIn('[data-test-modal-split-input-pm="auto"]', 6);
+
+    // total for sat should be 15
+    await fillIn('[data-test-modal-split-input-saturday="taxi"]', 7);
+    await fillIn('[data-test-modal-split-input-saturday="bus"]', 8);
+
+    // tests for total.am, total.md, total.pm, total.saturday in computed property `total`
+    assert.equal(this.element.querySelector('[data-test-total-am]').textContent, '3', 'total am calculated');
+    assert.equal(this.element.querySelector('[data-test-total-md]').textContent, '7', 'total md calculated');
+    assert.equal(this.element.querySelector('[data-test-total-pm]').textContent, '11', 'total pm calculated');
+    assert.equal(this.element.querySelector('[data-test-total-saturday]').textContent, '15', 'total saturday calculated');
   });
 });


### PR DESCRIPTION
### Tests
On the component `transportation/tdf/modal-splits` when a user enters the manual mode splits for each mode (e.g. `auto`, `taxi`, `bus`, etc.), the totals (calculated in the computed property `total`), are calculated correctly for each time of day (am, md, pm, saturday). 

Addresses #564 

Part of broader testing issue #557 

Code coverage increase includes lines in the computed property `total` in `modal-splits.js` file

https://codecov.io/gh/NYCPlanning/ceqr-app/src/baeee5a95da9826e2150c06130278e582c994887/frontend/app/components/transportation/tdf/modal-splits.js