### PR TITLE
564 all periods mode splits manual input test

### DIFF
--- a/frontend/app/components/transportation/tdf/modal-splits.js
+++ b/frontend/app/components/transportation/tdf/modal-splits.js
@@ -26,6 +26,10 @@ export default class TransportationTdfModalSplitsComponent extends Component {
     'modeSplits.{auto,taxi,bus,subway,railroad,walk,ferry,streetcar,bicycle,motorcycle,other}.{allPeriods,am,pm,md,saturday}',
   )
   get total() {
+    // modesForAnalysis = e.g. ['auto', 'taxi', 'bus', 'subway', 'walk', 'railroad']
+    // modeSplits = e.g. { auto: { allPeriods: 10.1, count: 2712 }, taxi: { allPeriods: 3.6, count: 981 } }
+    // reduce function to add up the am/md/pm/saturday/allPeriods values for each mode in the modesForAnalysis array
+    // example: auto saturday value + taxi saturday value + bus saturday value + subway saturday value
     return {
       allPeriods: this.factor.modesForAnalysis.reduce((pv, key) => pv + parseFloat(this.modeSplits[key].allPeriods), 0),
       am: this.factor.modesForAnalysis.reduce((pv, key) => pv + parseFloat(this.modeSplits[key].am), 0),

--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -82,7 +82,7 @@
             <td data-test-total-pm>{{total.pm}}</td>
             <td data-test-total-saturday>{{total.saturday}}</td>
           {{else}}
-            <td>
+            <td data-test-total-all-periods>
               {{total.allPeriods}} % 
               {{#if (not manualModeSplits)}}
                 ({{total.count}})

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
@@ -48,7 +48,7 @@
   {{else}}
     <td>
       <div class="ui right labeled input">
-        {{input type="number" max="100" min="0" step="0.1" value=allPeriodPercent}}
+        {{input type="number" max="100" min="0" step="0.1" value=allPeriodPercent data-test-modal-split-input-allperiods=mode}}
         <div class="ui basic label">
           %
         </div>


### PR DESCRIPTION
### Tests
Add a test for All Periods tab on the component `transportation/tdf/modal-splits` checking that if a user enters modal split values that the total will calculate correctly at the bottom of the table through the computed property `total` in modal-splits.js

Addresses #564 

Part of broader testing issue #557 
