### PR TITLE
564: test user can toggle between Manual and Census Tract tab on modal-splits component

### DIFF
--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -15,7 +15,12 @@
             <div class="ui small buttons">
               <button class="ui button {{if factor.manualModeSplits "positive"}}" onClick={{action toggleManualModeSplits}}>Manual</button>
               <div class="or"></div>
-              <button class="ui button {{if (not factor.manualModeSplits) "positive"}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
+              <button 
+                class="ui button {{if (not factor.manualModeSplits) "positive"}}" 
+                onClick={{action toggleCensusTractModeSplits}}
+                data-test-button="census tracts tab">
+                Census Tracts
+              </button>
             </div>
           </td>
           <td colspan={{if factor.temporalModeSplits "4" "1"}}>
@@ -134,7 +139,12 @@
         <tr>
           <td>
             <div class="ui small buttons">
-              <button class="ui button {{if factor.manualModeSplits "positive"}}" onClick={{action toggleManualModeSplits}}>Manual</button>
+              <button 
+                class="ui button {{if factor.manualModeSplits "positive"}}" 
+                onClick={{action toggleManualModeSplits}}
+                data-test-button="manual tab">
+                Manual
+              </button>
               <div class="or"></div>
               <button class="ui button {{if (not factor.manualModeSplits) "positive"}}" onClick={{action toggleCensusTractModeSplits}}>Census Tracts</button>
             </div>

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
@@ -56,7 +56,7 @@
     </td>
   {{/if}}
 {{else}}    
-  <td>
+  <td data-test-all-period-percent-value={{mode}}>
     {{allPeriodPercent}} % ({{count}})
   </td>
 {{/if}}


### PR DESCRIPTION
### Tests
Add a test that checks whether a user can toggle between Manual and Census Tracts tab on the `transportation/tdf/modal-splits` component. 

Addresses #564 

Part of broader testing issue #557 