### PR TITLE
564: test that user can add/remove modes on modal-splits component

### DIFF
--- a/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits.hbs
@@ -45,11 +45,11 @@
           <th class="four wide">
             <span style="color: #2185D0;">Mode</span>
               {{#if editModes}}
-                <div class="ui tiny blue button" onClick={{action "toggleEditModes"}}>
+                <div class="ui tiny blue button" onClick={{action "toggleEditModes"}} data-test-button="exit edit mode">
                   Ok
                 </div>
               {{else}}
-                <i class="icon blue pencil alternate" onClick={{action "toggleEditModes"}} style="cursor: pointer;"></i>
+                <i class="icon blue pencil alternate" onClick={{action "toggleEditModes"}} style="cursor: pointer;" data-test-button="enter edit mode"></i>
               {{/if}}
           </th>
           {{#if factor.temporalModeSplits}}
@@ -86,6 +86,7 @@
             @showInput={{manualModeSplits}}
             @showTemporalModeSplits={{factor.temporalModeSplits}}
             @editModes={{editModes}}
+            data-test-active-mode={{mode}}
           />
         {{/each}}
 
@@ -118,6 +119,7 @@
               @showInput={{manualModeSplits}}
               @showTemporalModeSplits={{factor.temporalModeSplits}}
               @editModes={{editModes}}
+              data-test-inactive-mode={{mode}}
             />
           {{/each}}
         {{/if}}

--- a/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
+++ b/frontend/app/templates/components/transportation/tdf/modal-splits/table-row.hbs
@@ -1,10 +1,11 @@
-<td>
+<td data-test-row-mode-title={{mode}}>
   {{#if editModes}}
     <UiCheckbox
       @checked={{modeActive}}
       @value={{mode}}
       @onChecked={{action addActiveMode}}
       @onUnchecked={{action removeActiveMode}}
+      data-test-checkbox={{mode}}
     />  
   {{/if}}
 


### PR DESCRIPTION
### Tests
Add test for component `transportation/tdf/modal-splits` checking that user can add and remove modes (e.g. "taxi") to the modes list.

Addresses #564 

Part of broader issue #557 