### PR TITLE
Fix bug w personTrips CP in tripResultsTotals calculator

### DIFF
--- a/frontend/app/calculators/transportation/trip-results-totals.js
+++ b/frontend/app/calculators/transportation/trip-results-totals.js
@@ -27,8 +27,8 @@ export default class TransportationTripResultsTotalsCalculator extends EmberObje
         // should actually be `+= personTrips`.
         // Get a second opinion on this before fixing.
         this.tripResults.forEach(({ personTrips }) => {
-          inTotal = +personTrips[temporalId][mode].in;
-          outTotal = +personTrips[temporalId][mode].out;
+          inTotal += personTrips[temporalId][mode].in;
+          outTotal += personTrips[temporalId][mode].out;
         });
 
         results[temporalId][mode] = {

--- a/frontend/tests/unit/calculators/trip-results-totals-test.js
+++ b/frontend/tests/unit/calculators/trip-results-totals-test.js
@@ -204,73 +204,41 @@ module('Unit | Calculator | transportation-trip-results-totals', function (hooks
     assert.deepEqual(newTtrtCalc.personTrips, {
       am: {
         auto: {
+          in: 12,
+          out: 12,
+          total: 24,
+        },
+        taxi: {
           in: 6,
           out: 6,
           total: 12,
         },
-        taxi: {
-          in: 3,
-          out: 3,
-          total: 6,
-        },
         bus: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        subway: {
-          in: 51,
-          out: 51,
-          total: 102,
-        },
-        railroad: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        walk: {
-          in: 31,
-          out: 31,
-          total: 62,
-        },
-      },
-      md: {
-        auto: {
-          in: 3,
-          out: 3,
-          total: 6,
-        },
-        taxi: {
           in: 2,
           out: 2,
           total: 4,
         },
-        bus: {
-          in: 0,
-          out: 0,
-          total: 0,
-        },
         subway: {
-          in: 25,
-          out: 25,
-          total: 50,
+          in: 102,
+          out: 102,
+          total: 204,
         },
         railroad: {
-          in: 1,
-          out: 1,
-          total: 2,
+          in: 2,
+          out: 2,
+          total: 4,
         },
         walk: {
-          in: 15,
-          out: 15,
-          total: 30,
+          in: 62,
+          out: 62,
+          total: 124,
         },
       },
-      pm: {
+      md: {
         auto: {
-          in: 7,
-          out: 7,
-          total: 14,
+          in: 6,
+          out: 6,
+          total: 12,
         },
         taxi: {
           in: 4,
@@ -278,14 +246,14 @@ module('Unit | Calculator | transportation-trip-results-totals', function (hooks
           total: 8,
         },
         bus: {
-          in: 1,
-          out: 1,
-          total: 2,
+          in: 0,
+          out: 0,
+          total: 0,
         },
         subway: {
-          in: 56,
-          out: 56,
-          total: 112,
+          in: 50,
+          out: 50,
+          total: 100,
         },
         railroad: {
           in: 2,
@@ -293,41 +261,73 @@ module('Unit | Calculator | transportation-trip-results-totals', function (hooks
           total: 4,
         },
         walk: {
-          in: 34,
-          out: 34,
-          total: 68,
+          in: 30,
+          out: 30,
+          total: 60,
+        },
+      },
+      pm: {
+        auto: {
+          in: 14,
+          out: 14,
+          total: 28,
+        },
+        taxi: {
+          in: 8,
+          out: 8,
+          total: 16,
+        },
+        bus: {
+          in: 2,
+          out: 2,
+          total: 4,
+        },
+        subway: {
+          in: 112,
+          out: 112,
+          total: 224,
+        },
+        railroad: {
+          in: 4,
+          out: 4,
+          total: 8,
+        },
+        walk: {
+          in: 68,
+          out: 68,
+          total: 136,
         },
       },
       saturday: {
         auto: {
+          in: 12,
+          out: 12,
+          total: 24,
+        },
+        taxi: {
           in: 6,
           out: 6,
           total: 12,
         },
-        taxi: {
-          in: 3,
-          out: 3,
-          total: 6,
-        },
         bus: {
-          in: 1,
-          out: 1,
-          total: 2,
+          in: 2,
+          out: 2,
+          total: 4,
         },
         subway: {
-          in: 48,
-          out: 48,
-          total: 96,
+          in: 96,
+          out: 96,
+          total: 192,
         },
         railroad: {
-          in: 1,
-          out: 1,
-          total: 2,
+          in: 2,
+          out: 2,
+          total: 4,
         },
         walk: {
-          in: 29,
-          out: 29,
-          total: 58,
+          in: 58,
+          out: 58,
+          total: 116,
         },
       },
     });


### PR DESCRIPTION
While working on #596 , I noticed that the personTrips computed simply uses the values from the last `tripResults` object in the `tripResults[]` array to calculate its totals. It looks like the intention of the code is to actually sum values across all `tripResults` objects within `tripResults[]` array, but while looping across `tripResults` objects the `+=` operator was accidentally written as `= +`.