### PR TITLE
589 Test for vehicleTrips CP in tripResultsTotals calculator

### DIFF
--- a/frontend/tests/unit/calculators/trip-results-totals-test.js
+++ b/frontend/tests/unit/calculators/trip-results-totals-test.js
@@ -2,181 +2,190 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ttrtCalc from 'labs-ceqr/calculators/transportation/trip-results-totals';
 
-const createTripResult = function() {
+const sampleTripData = function () {
   return {
-    personTrips: {
-      am: {
-        total: {
-          in: 93,
-          out: 93,
-          total: 186,
-        },
-        auto: {
-          in: 6,
-          out: 6,
-          total: 12,
-        },
-        taxi: {
-          in: 3,
-          out: 3,
-          total: 6,
-        },
-        bus: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        subway: {
-          in: 51,
-          out: 51,
-          total: 102,
-        },
-        railroad: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        walk: {
-          in: 31,
-          out: 31,
-          total: 62,
-        },
-        allModesTotal: {
-          in: 92.86249999999998,
-          out: 92.86249999999998,
-          total: 185.72499999999997,
-        },
+    am: {
+      total: {
+        in: 93,
+        out: 93,
+        total: 186,
       },
-      md: {
-        total: {
-          in: 46,
-          out: 46,
-          total: 92,
-        },
-        auto: {
-          in: 3,
-          out: 3,
-          total: 6,
-        },
-        taxi: {
-          in: 2,
-          out: 2,
-          total: 4,
-        },
-        bus: {
-          in: 0,
-          out: 0,
-          total: 0,
-        },
-        subway: {
-          in: 25,
-          out: 25,
-          total: 50,
-        },
-        railroad: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        walk: {
-          in: 15,
-          out: 15,
-          total: 30,
-        },
-        allModesTotal: {
-          in: 46.43124999999999,
-          out: 46.43124999999999,
-          total: 92.86249999999998,
-        },
+      auto: {
+        in: 6,
+        out: 6,
+        total: 12,
       },
-      pm: {
-        total: {
-          in: 104,
-          out: 104,
-          total: 208,
-        },
-        auto: {
-          in: 7,
-          out: 7,
-          total: 14,
-        },
-        taxi: {
-          in: 4,
-          out: 4,
-          total: 8,
-        },
-        bus: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        subway: {
-          in: 56,
-          out: 56,
-          total: 112,
-        },
-        railroad: {
-          in: 2,
-          out: 2,
-          total: 4,
-        },
-        walk: {
-          in: 34,
-          out: 34,
-          total: 68,
-        },
-        allModesTotal: {
-          in: 102.14874999999998,
-          out: 102.14874999999998,
-          total: 204.29749999999996,
-        },
+      taxi: {
+        in: 3,
+        out: 3,
+        total: 6,
       },
-      saturday: {
-        total: {
-          in: 88,
-          out: 88,
-          total: 176,
-        },
-        auto: {
-          in: 6,
-          out: 6,
-          total: 12,
-        },
-        taxi: {
-          in: 3,
-          out: 3,
-          total: 6,
-        },
-        bus: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        subway: {
-          in: 48,
-          out: 48,
-          total: 96,
-        },
-        railroad: {
-          in: 1,
-          out: 1,
-          total: 2,
-        },
-        walk: {
-          in: 29,
-          out: 29,
-          total: 58,
-        },
-        allModesTotal: {
-          in: 88.32,
-          out: 88.32,
-          total: 176.64,
-        },
+      bus: {
+        in: 1,
+        out: 1,
+        total: 2,
+      },
+      subway: {
+        in: 51,
+        out: 51,
+        total: 102,
+      },
+      railroad: {
+        in: 1,
+        out: 1,
+        total: 2,
+      },
+      walk: {
+        in: 31,
+        out: 31,
+        total: 62,
+      },
+      allModesTotal: {
+        in: 92.86249999999998,
+        out: 92.86249999999998,
+        total: 185.72499999999997,
+      },
+    },
+    md: {
+      total: {
+        in: 46,
+        out: 46,
+        total: 92,
+      },
+      auto: {
+        in: 3,
+        out: 3,
+        total: 6,
+      },
+      taxi: {
+        in: 2,
+        out: 2,
+        total: 4,
+      },
+      bus: {
+        in: 0,
+        out: 0,
+        total: 0,
+      },
+      subway: {
+        in: 25,
+        out: 25,
+        total: 50,
+      },
+      railroad: {
+        in: 1,
+        out: 1,
+        total: 2,
+      },
+      walk: {
+        in: 15,
+        out: 15,
+        total: 30,
+      },
+      allModesTotal: {
+        in: 46.43124999999999,
+        out: 46.43124999999999,
+        total: 92.86249999999998,
+      },
+    },
+    pm: {
+      total: {
+        in: 104,
+        out: 104,
+        total: 208,
+      },
+      auto: {
+        in: 7,
+        out: 7,
+        total: 14,
+      },
+      taxi: {
+        in: 4,
+        out: 4,
+        total: 8,
+      },
+      bus: {
+        in: 1,
+        out: 1,
+        total: 2,
+      },
+      subway: {
+        in: 56,
+        out: 56,
+        total: 112,
+      },
+      railroad: {
+        in: 2,
+        out: 2,
+        total: 4,
+      },
+      walk: {
+        in: 34,
+        out: 34,
+        total: 68,
+      },
+      allModesTotal: {
+        in: 102.14874999999998,
+        out: 102.14874999999998,
+        total: 204.29749999999996,
+      },
+    },
+    saturday: {
+      total: {
+        in: 88,
+        out: 88,
+        total: 176,
+      },
+      auto: {
+        in: 6,
+        out: 6,
+        total: 12,
+      },
+      taxi: {
+        in: 3,
+        out: 3,
+        total: 6,
+      },
+      bus: {
+        in: 1,
+        out: 1,
+        total: 2,
+      },
+      subway: {
+        in: 48,
+        out: 48,
+        total: 96,
+      },
+      railroad: {
+        in: 1,
+        out: 1,
+        total: 2,
+      },
+      walk: {
+        in: 29,
+        out: 29,
+        total: 58,
+      },
+      allModesTotal: {
+        in: 88.32,
+        out: 88.32,
+        total: 176.64,
       },
     },
   };
 };
 
+const createTripResultWithPersonTrips = function() {
+  return {
+    personTrips: sampleTripData(),
+  };
+};
+
+const createTripResultWithVehicleTrips = function() {
+  return {
+    vehicleTrips: sampleTripData(),
+  };
+};
 
 module('Unit | Calculator | transportation-trip-results-totals', function (hooks) {
   setupTest(hooks);
@@ -192,8 +201,8 @@ module('Unit | Calculator | transportation-trip-results-totals', function (hooks
     ];
 
     const tripResults = [
-      createTripResult(),
-      createTripResult(),
+      createTripResultWithPersonTrips(),
+      createTripResultWithPersonTrips(),
     ];
 
     const newTtrtCalc = ttrtCalc.create({
@@ -328,6 +337,158 @@ module('Unit | Calculator | transportation-trip-results-totals', function (hooks
           in: 58,
           out: 58,
           total: 116,
+        },
+      },
+    });
+  });
+
+  test('it calculates vehicleTrips', function (assert) {
+    const modes = [
+      'auto',
+      'taxi',
+      'bus',
+      'subway',
+      'railroad',
+      'walk',
+    ];
+
+    const tripResults = [
+      createTripResultWithVehicleTrips(),
+      createTripResultWithVehicleTrips(),
+    ];
+
+    const newTtrtCalc = ttrtCalc.create({
+      tripResults,
+      modes,
+    });
+
+    assert.deepEqual(newTtrtCalc.vehicleTrips, {
+      am: {
+        auto: {
+          in: 6,
+          out: 6,
+          total: 12,
+        },
+        bus: {
+          in: 1,
+          out: 1,
+          total: 2,
+        },
+        railroad: {
+          in: 1,
+          out: 1,
+          total: 2,
+        },
+        subway: {
+          in: 51,
+          out: 51,
+          total: 102,
+        },
+        taxi: {
+          in: 3,
+          out: 3,
+          total: 6,
+        },
+        walk: {
+          in: 31,
+          out: 31,
+          total: 62,
+        },
+      },
+      md: {
+        auto: {
+          in: 3,
+          out: 3,
+          total: 6,
+        },
+        bus: {
+          in: 0,
+          out: 0,
+          total: 0,
+        },
+        railroad: {
+          in: 1,
+          out: 1,
+          total: 2,
+        },
+        subway: {
+          in: 25,
+          out: 25,
+          total: 50,
+        },
+        taxi: {
+          in: 2,
+          out: 2,
+          total: 4,
+        },
+        walk: {
+          in: 15,
+          out: 15,
+          total: 30,
+        },
+      },
+      pm: {
+        auto: {
+          in: 7,
+          out: 7,
+          total: 14,
+        },
+        bus: {
+          in: 1,
+          out: 1,
+          total: 2,
+        },
+        railroad: {
+          in: 2,
+          out: 2,
+          total: 4,
+        },
+        subway: {
+          in: 56,
+          out: 56,
+          total: 112,
+        },
+        taxi: {
+          in: 4,
+          out: 4,
+          total: 8,
+        },
+        walk: {
+          in: 34,
+          out: 34,
+          total: 68,
+        },
+      },
+      saturday: {
+        auto: {
+          in: 6,
+          out: 6,
+          total: 12,
+        },
+        bus: {
+          in: 1,
+          out: 1,
+          total: 2,
+        },
+        railroad: {
+          in: 1,
+          out: 1,
+          total: 2,
+        },
+        subway: {
+          in: 48,
+          out: 48,
+          total: 96,
+        },
+        taxi: {
+          in: 3,
+          out: 3,
+          total: 6,
+        },
+        walk: {
+          in: 29,
+          out: 29,
+          total: 58,
         },
       },
     });


### PR DESCRIPTION
This sets up a test for the vehicleTrips computed property in the tripResultsTotals calculator.

This is essentially identical to the test for #596 . Both  the `personTrips` and `vehicleTrips` CPs rely on an argument of type `tripResults []`, which is an array of `tripResults {}` objects. `tripResults {}` for `personTrips` are pared down to just the `personTrip` property, and for `vehicleTrips` are pared down to just the `vehicleTrips` property since these are the properties needed by their respective CPs.  

Since the shape of both `personTrips` and `vehicleTrips` value look the same, I also extracted out that value into a constant, `sampleTripData`. This is more of a code-shortening thing.

Let me know if you think this might be a return to the `beforeEach()` paradigm.