### PR TITLE
605 Test for normalizedUnits CP in tripResults calculator

### DIFF
--- a/frontend/app/calculators/transportation/trip-results.js
+++ b/frontend/app/calculators/transportation/trip-results.js
@@ -6,7 +6,7 @@ import EmberObject, { computed } from '@ember/object';
  * @constructor
  * @param {string} landUse
  * @param {integer} units
- * @param {object} project - an array of all mode ids
+ * @param {object} project - TODO: This looks unused. Remove it from this signature and instantiations of this calculator
  * @param {array} modes - array of modes to be analyzed
  * @param {object} modeSplits
  * @param {object} inOutSplits

--- a/frontend/tests/unit/calculators/trip-results-test.js
+++ b/frontend/tests/unit/calculators/trip-results-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import trCalc from 'labs-ceqr/calculators/transportation/trip-results';
+
+module('Unit | Calculator | transportation-trip-results', function (hooks) {
+  setupTest(hooks);
+
+  test('it calculates normalizedUnits', function (assert) {
+    const units = 5;
+    // landUse here is necessary for the Calculator to determine
+    // which default value of tripGenRatePerUnit is used
+    // in order to compute normalizedUnits.
+    const landUse = 'residential';
+
+    const newTrCalc = trCalc.create({
+      units,
+      landUse,
+    });
+
+    // round(units/tripGenRatePerUnit) = normalizedUnits
+    assert.equal(newTrCalc.normalizedUnits, 5);
+  });
+});


### PR DESCRIPTION
Sets up a simple unit test for the `normalizedUnits` CP in the TripResults calculator. That CP only depends on `units` and `landUse` properties in the TripResults calculator, so other properties are omitted from the calculator's instantiation.