### PR TITLE
Add basic rendering tests to nudge test coverage

### DIFF
--- a/frontend/tests/integration/components/project/project-area-selector-test.js
+++ b/frontend/tests/integration/components/project/project-area-selector-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | project/project-area-selector', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Project::ProjectAreaSelector />`);
+
+    assert.ok(this.element);
+
+    // Template block usage:
+    await render(hbs`
+      <Project::ProjectAreaSelector>
+        template block text
+      </Project::ProjectAreaSelector>
+    `);
+
+    assert.ok(this.element);
+  });
+});

--- a/frontend/tests/integration/components/public-schools/summary-test.js
+++ b/frontend/tests/integration/components/public-schools/summary-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | public-schools/summary', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders', async function(assert) {
+    const store = this.owner.lookup('service:store');
+
+    this.server.create('public-schools-analysis', { id: 1 });
+    this.analysis = await store.findRecord('public-schools-analysis', 1);
+
+    await render(hbs`
+      <PublicSchools::Summary
+        @analysis={{this.analysis}}
+      />
+    `);
+
+    assert.ok(this.element);
+  });
+});


### PR DESCRIPTION
There are no test files for these components. This PR adds test files for them and renders the components so they appear in test coverage. The only assertion is that they load without exceptions thrown.