### PR TITLE
617: shadow only shows up under land use menu when user scrolls/it becomes sticky

### DIFF
--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -330,8 +330,15 @@ table.school-summary-sections {
 
 .transpo-factors-bar {
   background-color: rgba(255, 255, 255, 1);
-  box-shadow: 0 7px 2px -2px rgba(0,0,0,0.1);
   position: relative;
+}
+
+.sticky-element--sticky {
+  .transpo-factors-bar {
+    background-color: rgba(255, 255, 255, 1);
+    box-shadow: 0 7px 2px -2px rgba(0,0,0,0.1);
+    position: relative;
+  }
 }
 
 .mapboxgl-accessibility-marker {


### PR DESCRIPTION
Make it so that the shadow under the land use menu only shows up when a user scrolls (when the land use menu component gets a sticky class). 