### PR TITLE
590 Adjust fast food condition of Detailed Analysis trigger 

### DIFF
--- a/frontend/app/models/transportation-analysis.js
+++ b/frontend/app/models/transportation-analysis.js
@@ -56,11 +56,11 @@ export default class TransportationAnalysisModel extends Model {
   // Detailed Analysis trigger
   @computed(
     'sumOfRatios',
-    'hasFastFood',
+    'hasFastFoodGte2500',
   )
   get detailedAnalysis() {
     return (
-      this.hasFastFood
+      this.hasFastFoodGte2500
       || this.hasCommunityFacility
       || this.sumOfRatiosOver1
     );
@@ -95,9 +95,9 @@ export default class TransportationAnalysisModel extends Model {
   }
 
   // Fast Food boolean
-  @computed('project.commercialLandUse.[]')
-  get hasFastFood() {
-    return !!this.get('project.commercialLandUse').findBy('type', 'fast-food');
+  @computed('fastFoodSqFt')
+  get hasFastFoodGte2500() {
+    return this.fastFoodSqFt >= 2500;
   }
 
   // Community Facilities boolean
@@ -160,6 +160,18 @@ export default class TransportationAnalysisModel extends Model {
   @computed('restaurantSqFt')
   get restaurantSqFtRatio() {
     return this.ratioFor('restaurantSqFt');
+  }
+
+  // Fast food sq ft
+  // Here reduce() is used to be defensive, in case the commercialLandUse
+  // array can have multiple objects of type `fast-food`. However the "New Project" UI
+  // currently suggests only one fast-food land use can be created per project.
+  @computed('project.commercialLandUse.[]')
+  get fastFoodSqFt() {
+    return this
+      .get('project.commercialLandUse')
+      .filter((landUse) => landUse.type === 'fast-food')
+      .reduce((landUseTotalSqFt, curLandUse) => landUseTotalSqFt + curLandUse.grossSqFt, 0);
   }
 
   // Community Facility sq ft

--- a/frontend/tests/acceptance/detailed-analysis-trigger-test.js
+++ b/frontend/tests/acceptance/detailed-analysis-trigger-test.js
@@ -169,4 +169,78 @@ module('Acceptance | detailed analysis trigger', function(hooks) {
 
     assert.equal(detailedAnalysisAnswer, 'No');
   });
+
+  test('Fast food restaurant of 2500 sqft or more TRIGGERS a detailed analysis', async function(assert) {
+    this.server.create('user');
+    this.server.create('project', {
+      // Override factory default of 1000 totalUnits
+      totalUnits: 0,
+      seniorUnits: 0,
+      affordableUnits: 0,
+      commercialLandUse: [
+        {
+          type: 'fast-food',
+          grossSqFt: 2500,
+        },
+      ],
+      industrialLandUse: [],
+      communityFacilityLandUse: [],
+      parkingLandUse: [],
+      transportationAnalysis: this.server.create('transportationAnalysis', {
+        trafficZone: 1,
+      }),
+    });
+
+    await visit('/');
+    await fillIn('[data-test-login-form="email"]', 'user@email.com');
+    await fillIn('[data-test-login-form="password"]', 'password');
+    await click('[data-test-login-form="login"]');
+
+    await click('[data-test-project="1"]');
+
+    await click('[data-test-chapter="transportation"]');
+
+    assert.equal(currentURL(), '/project/1/transportation');
+
+    const detailedAnalysisAnswer = this.element.querySelector('[data-test-transportation-detailed-analysis-answer]').textContent.trim();
+
+    assert.equal(detailedAnalysisAnswer, 'Yes');
+  });
+
+  test('Fast food restaurant UNDER 2500 sqft DOES NOT in itself trigger a detailed analysis', async function(assert) {
+    this.server.create('user');
+    this.server.create('project', {
+      // Override factory default of 1000 totalUnits
+      totalUnits: 0,
+      seniorUnits: 0,
+      affordableUnits: 0,
+      commercialLandUse: [
+        {
+          type: 'fast-food',
+          grossSqFt: 2499,
+        },
+      ],
+      industrialLandUse: [],
+      communityFacilityLandUse: [],
+      parkingLandUse: [],
+      transportationAnalysis: this.server.create('transportationAnalysis', {
+        trafficZone: 1,
+      }),
+    });
+
+    await visit('/');
+    await fillIn('[data-test-login-form="email"]', 'user@email.com');
+    await fillIn('[data-test-login-form="password"]', 'password');
+    await click('[data-test-login-form="login"]');
+
+    await click('[data-test-project="1"]');
+
+    await click('[data-test-chapter="transportation"]');
+
+    assert.equal(currentURL(), '/project/1/transportation');
+
+    const detailedAnalysisAnswer = this.element.querySelector('[data-test-transportation-detailed-analysis-answer]').textContent.trim();
+
+    assert.equal(detailedAnalysisAnswer, 'No');
+  });
 });

--- a/frontend/tests/unit/models/transportation-analysis-test.js
+++ b/frontend/tests/unit/models/transportation-analysis-test.js
@@ -103,7 +103,7 @@ module('Unit | Model | transportation analysis', function(hooks) {
           {
             name: 'Fast Food Restaurant',
             type: 'fast-food',
-            grossSqFt: 40,
+            grossSqFt: 2500,
           },
         ],
       }),
@@ -186,21 +186,21 @@ module('Unit | Model | transportation analysis', function(hooks) {
     const analysisNoConditions = await projectNoConditions.get('transportationAnalysis');
 
     // Fast Food
-    assert.equal(analysisFastFood.hasFastFood, true);
-    assert.equal(analysisFastFood.detailedAnalysis, true); // true if hasFastFood OR hasCommunityFacility OR sumOfRatiosOver1 is true
+    assert.equal(analysisFastFood.hasFastFoodGte2500, true);
+    assert.equal(analysisFastFood.detailedAnalysis, true);
 
     // Community Facility
     assert.equal(analysisCommunityFacility.hasCommunityFacility, true);
-    assert.equal(analysisCommunityFacility.detailedAnalysis, true); // true if hasFastFood OR hasCommunityFacility OR sumOfRatiosOver1 is tru
+    assert.equal(analysisCommunityFacility.detailedAnalysis, true);
 
     // sumOfRatiosOver1
     assert.equal(analysisSumOfRatiosOver1.sumOfRatiosOver1, true);
-    assert.equal(analysisSumOfRatiosOver1.detailedAnalysis, true); // true if hasFastFood OR hasCommunityFacility OR sumOfRatiosOver1 is true
+    assert.equal(analysisSumOfRatiosOver1.detailedAnalysis, true);
 
     // None of the above conditions
-    assert.equal(analysisNoConditions.hasFastFood, false);
+    assert.equal(analysisNoConditions.hasFastFoodGte2500, false);
     assert.equal(analysisNoConditions.hasCommunityFacility, false);
     assert.equal(analysisNoConditions.sumOfRatiosOver1, false);
-    assert.equal(analysisNoConditions.detailedAnalysis, false); // false if does NOT have FastFood, Community Facility OR sumOfRatiosOver1
+    assert.equal(analysisNoConditions.detailedAnalysis, false);
   });
 });


### PR DESCRIPTION
Stakeholders clarified that only Fast Food land use of 2500 gsf or more should trigger a transportation Detailed Analysis, not the existence of Fast Food land use itself.

This commit adjusts the Detailed Analysis accordingly and adds corresponding acceptance tests.