### PR TITLE
630: update frontend model to match data updates ceqr_school_building

### DIFF
--- a/frontend/app/components/public-schools/existing-conditions/existing-conditions-steps.js
+++ b/frontend/app/components/public-schools/existing-conditions/existing-conditions-steps.js
@@ -9,4 +9,8 @@ export default Component.extend({
       || this.analysis.subdistrictsFromDb.length > 1
     );
   }),
+
+  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
+    return this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+  }),
 });

--- a/frontend/app/components/public-schools/existing-conditions/recently-built-schools.js
+++ b/frontend/app/components/public-schools/existing-conditions/recently-built-schools.js
@@ -1,6 +1,15 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
+  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
+    return this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+  }),
+
+  doeLcgmsMetadata: computed('analysis.dataPackage.schemas.ceqr_school_buildings.sources', function() {
+    return this.analysis.dataPackage.schemas.ceqr_school_buildings.sources.find((source) => source.name === 'lcgms');
+  }),
+
   actions: {
     save() {
       this.set('saving', true);

--- a/frontend/app/components/public-schools/existing-conditions/table-existing-conditions.js
+++ b/frontend/app/components/public-schools/existing-conditions/table-existing-conditions.js
@@ -20,6 +20,10 @@ export default Component.extend({
     }
   },
 
+  scaBluebookMetadata: computed('analysis.dataPackage.schemas.ceqr_school_buildings.sources', function() {
+    return this.analysis.dataPackage.schemas.ceqr_school_buildings.sources.find((source) => source.name === 'bluebook');
+  }),
+
   table: computed('activeSdId', 'activeSchoolsLevel', function() {
     if (this.activeSchoolsLevel === 'hs') {
       return this.analysis.subdistrictTotals.findBy('level', 'hs');

--- a/frontend/app/components/public-schools/summary.js
+++ b/frontend/app/components/public-schools/summary.js
@@ -19,8 +19,9 @@ export default Component.extend({
     }
   }),
 
-  EC_newSchoolsOpened: computed('activeSchoolsLevel', 'analysis.lcmgs', function() {
-    const schools = this.analysis.lcgms.filterBy('level', this.activeSchoolsLevel);
+  EC_newSchoolsOpened: computed('activeSchoolsLevel', 'analysis.ceqr_school_buildings', function() {
+    const lcgmsSchools = this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+    const schools = lcgmsSchools.filterBy('level', this.activeSchoolsLevel);
 
     const enrollment = schools.mapBy('enroll').reduce((a, v) => a + parseFloat(v), 0);
     const capacity = schools.mapBy('capacity').reduce((a, v) => a + parseFloat(v), 0);

--- a/frontend/app/fragments/public-schools/School.js
+++ b/frontend/app/fragments/public-schools/School.js
@@ -16,12 +16,12 @@ import round from '../../utils/round';
  * @param {integer} subdistrict - Building's school subdistrict
  * @param {string} org_id - DOE Organization ID of school
  * @param {string} bldg_id - DOE Building ID of school
- * @param {string} grades - Grade levels serviced. Found only in LCGMS data
+ * @param {string} grades - Grade levels serviced. Found only in LCGMS data <-- TODO: is this still applicable?
  * @param {string} level - The level of the individual school. In other words, what level do the capacity and
  *   enroll numbers on this building contribute to. One of: ['ps', 'is', 'hs']
  * @param {string} org_level - The level of the organization
  * @param {string} source - The source of the data. One of: ['bluebook', 'lcgms']
- * @param {string} dataVersion - Version of LCGMS or Bluebook
+ * @param {string} dataVersion - Version of ceqr_school_buildings (combined bluebook and lcgms datasets)
  * @param {integer} capacity - School's current capacity
  * @param {integer} capacityFuture - School's future capacity, defaults to the same as capacity but a user can change this
  * @param {integer} enroll - School's current enrollment

--- a/frontend/app/models/public-schools-analysis.js
+++ b/frontend/app/models/public-schools-analysis.js
@@ -86,11 +86,10 @@ export default DS.Model.extend({
   }),
 
   // By Subdistrict
-  bluebook: DS.attr('public-schools/schools', { defaultValue() { return []; } }),
-  lcgms: DS.attr('public-schools/schools', { defaultValue() { return []; } }),
+  ceqr_school_buildings: DS.attr('public-schools/schools', { defaultValue() { return []; } }),
 
-  buildingsGeojson: computed('bluebook', 'lcgms', function() {
-    const buildings = this.bluebook.concat(this.get('lcgms'));
+  buildingsGeojson: computed('ceqr_school_buildings', function() {
+    const buildings = this.ceqr_schools_buildings;
 
     const features = buildings.map((b) => {
       const { geojson } = b;
@@ -130,11 +129,9 @@ export default DS.Model.extend({
     return turf.featureCollection(features);
   }),
 
-  buildings: computed('bluebook', 'lcgms', 'scaProjects', function() {
+  buildings: computed('ceqr_school_buildings', 'scaProjects', function() {
     return (
-      this.get('bluebook')
-    ).concat(
-      this.get('lcgms'),
+      this.get('ceqr_school_buildings')
     ).concat(
       this.get('scaProjects'),
     ).compact();
@@ -202,11 +199,9 @@ export default DS.Model.extend({
   futureEnrollmentNewHousing: DS.attr('', { defaultValue() { return []; } }),
 
   // Tables
-  allSchools: computed('bluebook', 'lcgms', function() {
+  allSchools: computed('ceqr_school_buildings', function() {
     return (
-      this.bluebook
-    ).concat(
-      this.lcgms,
+      this.ceqr_school_buildings
     ).compact();
   }),
 

--- a/frontend/app/templates/components/public-schools/existing-conditions/existing-conditions-steps.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/existing-conditions-steps.hbs
@@ -27,9 +27,9 @@
     }}
       Newly Opened Schools
       <div
-        class="ui label {{if (gt analysis.lcgms.length 0) "orange" "green"}}"
+        class="ui label {{if (gt this.newlyOpenedSchools.length 0) "orange" "green"}}"
       >
-        {{analysis.lcgms.length}}
+        {{this.newlyOpenedSchools.length}}
       </div>
     {{/link-to}}
   </div>

--- a/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
@@ -1,4 +1,4 @@
-{{#if analysis.lcgms}}
+{{#if this.newlyOpenedSchools}}
   <div class="ui message">
     <div class="header">
       Instructions
@@ -22,7 +22,7 @@
   <div class="ui top attached segment">
     <h4>
       Schools opened in
-      {{school-year analysis.dataPackage.schemas.doe_lcgms}}
+      {{school-year this.doeLcgmsMetadata}}
       school year not captured in Blue Book
     </h4>
   </div>
@@ -63,7 +63,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each analysis.lcgms as |b|}}
+      {{#each this.newlyOpenedSchools as |b|}}
         <TrHover
           class={{b.org_level}}
           @source="buildings"
@@ -132,7 +132,7 @@
           href="https://data.cityofnewyork.us/Education/LCGMS-DOE-School-Information-Report/3bkj-34v2"
         >
           DOE School Information Report (LCGMS) [
-          {{analysis.dataPackage.schemas.doe_lcgms.version}}
+          {{this.doeLcgmsMetadata.version}}
           ]
           <i class="external alternate icon"></i>
         </a>

--- a/frontend/app/templates/components/public-schools/existing-conditions/table-existing-conditions.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/table-existing-conditions.hbs
@@ -232,7 +232,7 @@
         href="http://www.nycsca.org/Community/Capital-Plan-Reports-Data#Enrollment-Capacity-Utilization-69"
       >
         SCA Enrollment, Capacity, and Utilization (Blue Book) [
-        {{school-year analysis.dataPackage.schemas.sca_bluebook}}
+        {{school-year this.scaBluebookMetadata}}
         ]
         <i class="external alternate icon"></i>
       </a>


### PR DESCRIPTION
JUST A DISCOVERY PR. Will create a new, more organized one once we have a better understanding of the frontend changes that are necessary after the data updates. 

Changes:
1) update public schools analysis model to no longer concatenate bluebook and lcgms and instead just have ceqr_school_buildings as a single array
2) create new computed scaBluebookMetadata on `table-existing-conditions` to replace `analysis.dataPackage.schemas.sca_bluebook` since data packages will now be formatted differently
3) create new computed on `existing-conditions-steps` newlyOpenedSchools to replace the display of only lcgms schools