### PR TITLE
627 Add ACS 2018 data package

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -204,6 +204,19 @@ if DataPackage.where(package: "nyc_acs", version: "2017").first.nil?
   })
 end
 
+if DataPackage.where(package: "nyc_acs", version: "2018").first.nil?
+  DataPackage.create({
+    name: "ACS 5-year 2018",
+    version: "2018",
+    package: "nyc_acs",
+    release_date: Date.parse('2019-12-19'),
+    schemas: {
+      "nyc_acs": { table: "2018" },
+      "nyc_census_tract_boundaries": { table: "2010" }
+    }
+  })
+end
+
 if DataPackage.where(package: "mappluto", version: "18v2").first.nil?
   DataPackage.create({
     name: "MapPLUTO 18v2",


### PR DESCRIPTION
This PR is part of a series of PRs addressing https://github.com/NYCPlanning/ceqr-app/issues/627 (see that issue for the game plan)

This PR modifies the adds the `db/seeds.rb` file to add the 2018 ACS package, which will point to the `ceqr_data` databases's `nyc_acs.2018` table. 

Note that before CircleCI tests for this change can pass, and before this PR can be merged into develop or master, the `nyc_acs.2018` table has to be loaded into production `ceqr_data`. It was done by following the pipeline introduced by PRs #643 and. #651  