### PR TITLE
630 frontend public schools data update refactor

### DIFF
--- a/frontend/app/components/public-schools/existing-conditions/existing-conditions-steps.js
+++ b/frontend/app/components/public-schools/existing-conditions/existing-conditions-steps.js
@@ -2,6 +2,12 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
+  // ceqr_school_buildings dataset is a combination of lcgms and bluebook datasets
+  // lcgms dataset represents schools that were opened recently
+  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
+    return this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+  }),
+
   displayWarning: computed('analysis.{esSchoolChoice,isSchoolChoice,subdistrictsFromDb}', function() {
     return (
       this.analysis.esSchoolChoice

--- a/frontend/app/components/public-schools/existing-conditions/existing-conditions-steps.js
+++ b/frontend/app/components/public-schools/existing-conditions/existing-conditions-steps.js
@@ -2,12 +2,6 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  // ceqr_school_buildings dataset is a combination of lcgms and bluebook datasets
-  // lcgms dataset represents schools that were opened recently
-  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
-    return this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
-  }),
-
   displayWarning: computed('analysis.{esSchoolChoice,isSchoolChoice,subdistrictsFromDb}', function() {
     return (
       this.analysis.esSchoolChoice

--- a/frontend/app/components/public-schools/existing-conditions/recently-built-schools.js
+++ b/frontend/app/components/public-schools/existing-conditions/recently-built-schools.js
@@ -1,6 +1,18 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
+  // ceqr_school_buildings dataset is a combination of two datasets lcgms and bluebook
+  // lcgms dataset represents schools that opened recently
+  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
+    return this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+  }),
+
+  // ceqr_school_buildings dataset is a combination of two datasets with different metadata: lcgms dataset and bluebook dataset
+  lcgmsMetadata: computed('analysis.dataPackage.schemas.ceqr_school_buildings.sources', function() {
+    return this.analysis.dataPackage.schemas.ceqr_school_buildings.sources.find((source) => source.name === 'lcgms');
+  }),
+
   actions: {
     save() {
       this.set('saving', true);

--- a/frontend/app/components/public-schools/existing-conditions/recently-built-schools.js
+++ b/frontend/app/components/public-schools/existing-conditions/recently-built-schools.js
@@ -2,12 +2,6 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  // ceqr_school_buildings dataset is a combination of two datasets lcgms and bluebook
-  // lcgms dataset represents schools that opened recently
-  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
-    return this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
-  }),
-
   // ceqr_school_buildings dataset is a combination of two datasets with different metadata: lcgms dataset and bluebook dataset
   lcgmsMetadata: computed('analysis.dataPackage.schemas.ceqr_school_buildings.sources', function() {
     return this.analysis.dataPackage.schemas.ceqr_school_buildings.sources.find((source) => source.name === 'lcgms');

--- a/frontend/app/components/public-schools/existing-conditions/table-existing-conditions.js
+++ b/frontend/app/components/public-schools/existing-conditions/table-existing-conditions.js
@@ -20,6 +20,11 @@ export default Component.extend({
     }
   },
 
+  // ceqr_school_buildings dataset is a combination of two datasets with different metadata: bluebook dataset and lcgms dataset
+  bluebookMetadata: computed('analysis.dataPackage.schemas.ceqr_school_buildings.sources', function() {
+    return this.analysis.dataPackage.schemas.ceqr_school_buildings.sources.find((source) => source.name === 'bluebook');
+  }),
+
   table: computed('activeSdId', 'activeSchoolsLevel', function() {
     if (this.activeSchoolsLevel === 'hs') {
       return this.analysis.subdistrictTotals.findBy('level', 'hs');

--- a/frontend/app/components/public-schools/project-map.js
+++ b/frontend/app/components/public-schools/project-map.js
@@ -104,24 +104,24 @@ export default Component.extend({
             <tr><th>Org Name</th><th>Org ID</th><th>Bldg ID</th><th>Level</th></tr>
           </thead>
         `;
-        schools.forEach((s) => {
-          this.dotHover({ source: s.layer_id, id: s.id });
-          this.get('tablehover').trigger('hover', { source: s.layer_id, id: s.id });
+        schools.forEach((school) => {
+          this.dotHover({ source: school.layer_id, id: school.id });
+          this.get('tablehover').trigger('hover', { source: school.layer_id, id: school.id });
 
           let org_name;
-          if (s.source === 'lcgms') {
-            org_name = `${s.name}<br>(newly built)`;
-          } else if (s.source === 'scaprojects') {
-            org_name = `${s.name}<br>(under construction)`;
+          if (school.source === 'lcgms') {
+            org_name = `${school.name}<br>(newly built)`;
+          } else if (school.source === 'scaprojects') {
+            org_name = `${school.name}<br>(under construction)`;
           } else {
-            org_name = s.name;
+            org_name = school.name;
           }
 
           const row = `<tr>
             <td>${org_name}</td>
-            <td>${s.org_id || ''}</td>
-            <td>${s.bldg_id || ''}</td>
-            <td>${s.level}</td>
+            <td>${school.org_id || ''}</td>
+            <td>${school.bldg_id || ''}</td>
+            <td>${school.level}</td>
           </tr>`;
           html += row;
         });

--- a/frontend/app/components/public-schools/summary.js
+++ b/frontend/app/components/public-schools/summary.js
@@ -22,7 +22,7 @@ export default Component.extend({
   EC_newSchoolsOpened: computed('activeSchoolsLevel', 'analysis.ceqr_school_buildings', function() {
     // ceqr_school_buildings dataset is a combination of lcgms and bluebook datasets
     // lcgms dataset represents schools that were opened recently
-    const lcgmsSchools = this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+    const lcgmsSchools = this.analysis.ceqr_school_buildings.filter((school) => school.source === 'lcgms');
     const activeLevelSchools = lcgmsSchools.filterBy('level', this.activeSchoolsLevel);
 
     const enrollment = activeLevelSchools.mapBy('enroll').reduce((a, v) => a + parseFloat(v), 0);

--- a/frontend/app/components/public-schools/summary.js
+++ b/frontend/app/components/public-schools/summary.js
@@ -19,13 +19,16 @@ export default Component.extend({
     }
   }),
 
-  EC_newSchoolsOpened: computed('activeSchoolsLevel', 'analysis.lcmgs', function() {
-    const schools = this.analysis.lcgms.filterBy('level', this.activeSchoolsLevel);
+  EC_newSchoolsOpened: computed('activeSchoolsLevel', 'analysis.ceqr_school_buildings', function() {
+    // ceqr_school_buildings dataset is a combination of lcgms and bluebook datasets
+    // lcgms dataset represents schools that were opened recently
+    const lcgmsSchools = this.analysis.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+    const activeLevelSchools = lcgmsSchools.filterBy('level', this.activeSchoolsLevel);
 
-    const enrollment = schools.mapBy('enroll').reduce((a, v) => a + parseFloat(v), 0);
-    const capacity = schools.mapBy('capacity').reduce((a, v) => a + parseFloat(v), 0);
+    const enrollment = activeLevelSchools.mapBy('enroll').reduce((a, v) => a + parseFloat(v), 0);
+    const capacity = activeLevelSchools.mapBy('capacity').reduce((a, v) => a + parseFloat(v), 0);
 
-    return { enrollment, capacity, schools };
+    return { enrollment, capacity, activeLevelSchools };
   }),
 
   NA_newResidentialDevelopment: computed('activeSchoolsLevel', function() {

--- a/frontend/app/fragments/public-schools/School.js
+++ b/frontend/app/fragments/public-schools/School.js
@@ -16,12 +16,11 @@ import round from '../../utils/round';
  * @param {integer} subdistrict - Building's school subdistrict
  * @param {string} org_id - DOE Organization ID of school
  * @param {string} bldg_id - DOE Building ID of school
- * @param {string} grades - Grade levels serviced. Found only in LCGMS data
  * @param {string} level - The level of the individual school. In other words, what level do the capacity and
  *   enroll numbers on this building contribute to. One of: ['ps', 'is', 'hs']
  * @param {string} org_level - The level of the organization
  * @param {string} source - The source of the data. One of: ['bluebook', 'lcgms']
- * @param {string} dataVersion - Version of LCGMS or Bluebook
+ * @param {string} dataVersion - Version of LCGMS or Bluebook, ceqr_school_buildings dataset is a combination lcgms dataset and bluebook dataset
  * @param {integer} capacity - School's current capacity
  * @param {integer} capacityFuture - School's future capacity, defaults to the same as capacity but a user can change this
  * @param {integer} enroll - School's current enrollment

--- a/frontend/app/helpers/school-year.js
+++ b/frontend/app/helpers/school-year.js
@@ -1,6 +1,8 @@
 import { helper } from '@ember/component/helper';
 
 export function schoolYear(schema) {
+  // helper functions take their arguments as an array
+  // we pass in an object here, but it's changed to [{}]
   if (schema[0]) {
     return `${schema[0].minYear}-${schema[0].maxYear}`;
   }

--- a/frontend/app/models/public-schools-analysis.js
+++ b/frontend/app/models/public-schools-analysis.js
@@ -140,6 +140,12 @@ export default DS.Model.extend({
     return this.get('buildings').mapBy('bldg_id').uniq();
   }),
 
+  // ceqr_school_buildings dataset is a combination of two datasets lcgms and bluebook
+  // lcgms dataset represents schools that opened recently
+  newlyOpenedSchools: computed('analysis.ceqr_school_buildings', function() {
+    return this.ceqr_school_buildings.find((school) => school.source === 'lcgms');
+  }),
+
   // Future
   projectionOverMax: computed('buildYear', function() {
     return this.get('buildYear') > this.get('maxProjection');

--- a/frontend/app/models/public-schools-analysis.js
+++ b/frontend/app/models/public-schools-analysis.js
@@ -86,11 +86,10 @@ export default DS.Model.extend({
   }),
 
   // By Subdistrict
-  bluebook: DS.attr('public-schools/schools', { defaultValue() { return []; } }),
-  lcgms: DS.attr('public-schools/schools', { defaultValue() { return []; } }),
+  ceqr_school_buildings: DS.attr('public-schools/schools', { defaultValue() { return []; } }),
 
-  buildingsGeojson: computed('bluebook', 'lcgms', function() {
-    const buildings = this.bluebook.concat(this.get('lcgms'));
+  buildingsGeojson: computed('ceqr_school_buildings', function() {
+    const buildings = this.ceqr_schools_buildings;
 
     const features = buildings.map((b) => {
       const { geojson } = b;
@@ -130,11 +129,9 @@ export default DS.Model.extend({
     return turf.featureCollection(features);
   }),
 
-  buildings: computed('bluebook', 'lcgms', 'scaProjects', function() {
+  buildings: computed('ceqr_school_buildings', 'scaProjects', function() {
     return (
-      this.get('bluebook')
-    ).concat(
-      this.get('lcgms'),
+      this.get('ceqr_school_buildings')
     ).concat(
       this.get('scaProjects'),
     ).compact();
@@ -202,11 +199,9 @@ export default DS.Model.extend({
   futureEnrollmentNewHousing: DS.attr('', { defaultValue() { return []; } }),
 
   // Tables
-  allSchools: computed('bluebook', 'lcgms', function() {
+  allSchools: computed('ceqr_school_buildings', function() {
     return (
-      this.bluebook
-    ).concat(
-      this.lcgms,
+      this.ceqr_school_buildings
     ).compact();
   }),
 

--- a/frontend/app/templates/components/public-schools/existing-conditions/existing-conditions-steps.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/existing-conditions-steps.hbs
@@ -27,9 +27,9 @@
     }}
       Newly Opened Schools
       <div
-        class="ui label {{if (gt analysis.lcgms.length 0) "orange" "green"}}"
+        class="ui label {{if (gt this.newlyOpenedSchools.length 0) "orange" "green"}}"
       >
-        {{analysis.lcgms.length}}
+        {{this.newlyOpenedSchools.length}}
       </div>
     {{/link-to}}
   </div>

--- a/frontend/app/templates/components/public-schools/existing-conditions/existing-conditions-steps.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/existing-conditions-steps.hbs
@@ -27,9 +27,9 @@
     }}
       Newly Opened Schools
       <div
-        class="ui label {{if (gt this.newlyOpenedSchools.length 0) "orange" "green"}}"
+        class="ui label {{if (gt analysis.newlyOpenedSchools.length 0) "orange" "green"}}"
       >
-        {{this.newlyOpenedSchools.length}}
+        {{analysis.newlyOpenedSchools.length}}
       </div>
     {{/link-to}}
   </div>

--- a/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
@@ -1,4 +1,4 @@
-{{#if this.newlyOpenedSchools}}
+{{#if analysis.newlyOpenedSchools}}
   <div class="ui message">
     <div class="header">
       Instructions
@@ -63,7 +63,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each this.newlyOpenedSchools as |school|}}
+      {{#each analysis.newlyOpenedSchools as |school|}}
         <TrHover
           class={{school.org_level}}
           @source="buildings"

--- a/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/recently-built-schools.hbs
@@ -1,4 +1,4 @@
-{{#if analysis.lcgms}}
+{{#if this.newlyOpenedSchools}}
   <div class="ui message">
     <div class="header">
       Instructions
@@ -22,7 +22,7 @@
   <div class="ui top attached segment">
     <h4>
       Schools opened in
-      {{school-year analysis.dataPackage.schemas.doe_lcgms}}
+      {{school-year this.lcgmsMetadata}}
       school year not captured in Blue Book
     </h4>
   </div>
@@ -63,52 +63,52 @@
       </tr>
     </thead>
     <tbody>
-      {{#each analysis.lcgms as |b|}}
+      {{#each this.newlyOpenedSchools as |school|}}
         <TrHover
-          class={{b.org_level}}
+          class={{school.org_level}}
           @source="buildings"
-          @id={{b.id}}
+          @id={{school.id}}
         >
           <td>
-            {{b.org_id}}
+            {{school.org_id}}
           </td>
           <td>
             <i class="icons">
               <i class="circle new-school-outline icon"></i>
               <i class="small circle school icon"></i>
             </i>
-            {{b.name}}
-            {{#if (not-eq b.name b.bldg_name)}}
+            {{school.name}}
+            {{#if (not-eq school.name school.bldg_name)}}
               <br>
               <em>
-                {{b.bldg_name}}
+                {{school.bldg_name}}
               </em>
             {{/if}}
           </td>
           <td>
-            {{b.grades}}
+            {{school.grades}}
           </td>
           <td>
-            {{b.address}}
+            {{school.address}}
           </td>
           <td>
-            {{b.level}}
+            {{school.level}}
           </td>
           <td class="warning">
             <div class="ui input transparent warning edit-cell">
-              {{input type="number" value=b.enroll placeholder="0"}}
+              {{input type="number" value=school.enroll placeholder="0"}}
             </div>
           </td>
           <td class="warning">
             <div class="ui input transparent warning edit-cell">
-              {{input type="number" value=b.capacity placeholder="0"}}
+              {{input type="number" value=school.capacity placeholder="0"}}
             </div>
           </td>
           <td>
-            {{b.seats}}
+            {{school.seats}}
           </td>
           <td>
-            {{if b.excluded "N/A" (percentage b.utilization)}}
+            {{if school.excluded "N/A" (percentage school.utilization)}}
           </td>
         </TrHover>
       {{/each}}
@@ -132,7 +132,7 @@
           href="https://data.cityofnewyork.us/Education/LCGMS-DOE-School-Information-Report/3bkj-34v2"
         >
           DOE School Information Report (LCGMS) [
-          {{analysis.dataPackage.schemas.doe_lcgms.version}}
+          {{this.lcgmsMetadata.version}}
           ]
           <i class="external alternate icon"></i>
         </a>

--- a/frontend/app/templates/components/public-schools/existing-conditions/table-existing-conditions.hbs
+++ b/frontend/app/templates/components/public-schools/existing-conditions/table-existing-conditions.hbs
@@ -232,7 +232,7 @@
         href="http://www.nycsca.org/Community/Capital-Plan-Reports-Data#Enrollment-Capacity-Utilization-69"
       >
         SCA Enrollment, Capacity, and Utilization (Blue Book) [
-        {{school-year analysis.dataPackage.schemas.sca_bluebook}}
+        {{school-year this.bluebookMetadata}}
         ]
         <i class="external alternate icon"></i>
       </a>

--- a/frontend/mirage/factories/public-schools-analysis.js
+++ b/frontend/mirage/factories/public-schools-analysis.js
@@ -301,9 +301,9 @@ export default Factory.extend({
     thresholdPsIsStudents: 50,
   }),
 
-  // TRAIT for list of schools, including bluebook, lcgms, and scaProjects
+  // TRAIT for list of schools, including ceqr_school_buildings and scaProjects
   schoolsForTests: trait({
-    bluebook: [
+    ceqr_school_buildings: [
       {
         name: 'I.S. 2 - K',
         org_id: 'K002',
@@ -360,9 +360,6 @@ export default Factory.extend({
         is_capacity: 200,
         level: 'hs',
       },
-    ],
-    // LCGMS SCHOOLS
-    lcgms: [
       {
         name: 'Banana Bonanza',
         bldg_id: 'LCGMS_BB1',
@@ -680,7 +677,7 @@ export default Factory.extend({
     },
   ],
   subdistrictsFromUser: () => [],
-  bluebook: () => [
+  ceqr_school_buildings: () => [
     {
       x: 997684,
       y: 178345,
@@ -5379,8 +5376,6 @@ export default Factory.extend({
       capacityFuture: 423,
       the_geom_webmercator: '0101000020110F000002FD5E0159635FC17991CEBC15F35241',
     },
-  ],
-  lcgms: () => [
     {
       name: 'P.S. 583',
       level: 'ps',

--- a/frontend/tests/unit/fragments/public-schools/school-test.js
+++ b/frontend/tests/unit/fragments/public-schools/school-test.js
@@ -7,13 +7,13 @@ module('Unit | Fragment | School', function(hooks) {
   setupTest(hooks);
 
   test('seats are calculated correctly', function(assert) {
-    const lcgms_school = School.create({
+    const school_a = School.create({
       enroll: 115,
       capacity: '',
       excluded: false,
     });
 
-    const bluebook_school = School.create({
+    const school_b = School.create({
       enroll: 115,
       capacity: 234,
       excluded: false,
@@ -25,8 +25,8 @@ module('Unit | Fragment | School', function(hooks) {
       excluded: true,
     });
 
-    assert.equal(lcgms_school.seats, 0);
-    assert.equal(bluebook_school.seats, 119);
+    assert.equal(school_a.seats, 0);
+    assert.equal(school_b.seats, 119);
     assert.equal(excluded_school.seats, -115);
   });
 

--- a/frontend/tests/unit/models/public-schools-analysis-test.js
+++ b/frontend/tests/unit/models/public-schools-analysis-test.js
@@ -255,7 +255,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
   test('concatenates buildings and allSchools correctly', async function(assert) {
     /*
       input variables:
-      * incorporates testsForSchools trait defined in the mirage factory with bluebook, lcgms, and scaProjects as the
+      * incorporates testsForSchools trait defined in the mirage factory with ceqr_school_buildings and scaProjects as the
       three different types of schools
 
       tested variables:
@@ -287,7 +287,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
     // "Cantelope Castle", "Donuts Delight", "Avocado Adventure", "Clementine Canopy", "Peach Party", "Passionfruit Pavilion",
     // "Tangerine Tent", "Pineapple Paradise", "Olive Oasis", "Grapefruit Garage"]
 
-    // buildings concatenates bluebook, lcgms, and scaProjects
+    // buildings concatenates ceqr_school_buildings and scaProjects
     assert.equal(bluebookBuildings[1].name, 'I.S. 61 - K');
     assert.equal(lcgmsBuildings[1].name, 'Strawberry Sunrise');
     assert.equal(scaProjectsBuildings[1].name, 'Avocado Adventure');
@@ -295,7 +295,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
     // analysis.allSchools.mapBy('name') =
     // ["I.S. 2 - K", "I.S. 61 - K", "Starfruit Sauna", "P.S. 91 - K", "Banana Bonanza", "Strawberry Sunrise", "Cantelope Castle"]
 
-    // allSchools concatenates bluebook and lcgms
+    // allSchools = ceqr_school_buildings
     assert.equal(bluebookSchools[1].name, 'I.S. 61 - K');
     assert.equal(lcgmsSchools[1].name, 'Strawberry Sunrise');
     // ^^ do we need to test that .compact works and that no null values are added to this allSchools concatenation?
@@ -360,16 +360,11 @@ module('Unit | Model | public schools analysis', function(hooks) {
         * doeUtilChanges.title (string)
         * doeUtilChanges.bldg_id (string)
         * doeUtilChanges.bldg_id_additional (string)
-      * bluebook (array of objects)
-        * bluebook.name (string)
-        * bluebook.source (string)
-        * bluebook.bldg_id (string)
-        * bluebook.level (string)
-      * lcgms (array of objects)
-        * lcgms.name (string)
-        * lcgms.source (string)
-        * lcgms.bldg_id (string)
-        * lcgms.level (string)
+      * ceqr_school_buildings (array of objects)
+        * ceqr_school_buildings.name (string)
+        * ceqr_school_buildings.source (string)
+        * ceqr_school_buildings.bldg_id (string)
+        * ceqr_school_buildings.level (string)
       * scaProjects (array of objects)
         * scaProjects.name (string)
         * scaProjects.source (string)
@@ -420,7 +415,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
           bldg_id_additional: '',
         },
       ],
-      bluebook: () => [
+      ceqr_school_buildings: () => [
         {
           name: 'Raspberry Railway',
           source: 'bluebook',
@@ -439,8 +434,6 @@ module('Unit | Model | public schools analysis', function(hooks) {
           bldg_id: 'BBSS1',
           level: 'is',
         },
-      ],
-      lcgms: () => [
         {
           name: 'Banana Bonanza',
           bldg_id: 'LCGMS_BB1',
@@ -467,7 +460,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
     assert.equal(analysis.doeUtilChangesBldgIds[4], 'additional_AA'); // checks that the additional building IDs start after the end of the bldg_id list
     assert.equal(analysis.doeUtilChangesBldgIds[8], 'additional_RR'); // checks that both the "" values under bldg_id and bldg_id_additional for "Organizing the Olive Oasis" are not included
 
-    // buildings is a concatenation of bluebook, lcgms, and scaProjects
+    // buildings is a concatenation of ceqr_school_buildings and scaProjects
     // analysis.buildings.mapBy('name') = [ "Raspberry Railway", "Plum Palace", "Starfruit Sauna", "Banana Bonanza", "Strawberry Sunrise"]
     assert.equal(analysis.buildings[3].name, 'Banana Bonanza');
 
@@ -497,7 +490,7 @@ module('Unit | Model | public schools analysis', function(hooks) {
     /*
       input variables:
       * this test incorporates all variables from the subdistrictTotalsTest trait in the public-schools-analysis mirage factory
-      * it also incorporates testsForSchools trait defined in the mirage factory with bluebook, lcgms, and scaProjects as the
+      * it also incorporates testsForSchools trait defined in the mirage factory with ceqr_school_buildings and scaProjects as the
       three different types of schools
 
       tested variables:
@@ -520,8 +513,8 @@ module('Unit | Model | public schools analysis', function(hooks) {
     const analysis = await project.get('publicSchoolsAnalysis');
 
     assert.equal(analysis.borough, 'Brooklyn');
-    assert.equal(analysis.allSchools[4].name, 'Banana Bonanza'); // 3rd school under bluebooks
-    assert.equal(analysis.subdistrictTotals[0].allBuildings[4].name, 'Banana Bonanza'); // allBuildings = this.allSchools = concatenated bluebook & lcgms projects
+    assert.equal(analysis.allSchools[4].name, 'Banana Bonanza'); // 3rd school for bluebooks
+    assert.equal(analysis.subdistrictTotals[0].allBuildings[4].name, 'Banana Bonanza'); // allBuildings = this.allSchools = ceqr_school_buildings
 
     // HS tables
     assert.equal(analysis.subdistrictTotals[0].studentMultiplier, 0.09); // currentMultiplier.hs


### PR DESCRIPTION
This PR implements the frontend changes necessary after the data update to combine the `lcgms` dataset and the `bluebook` dataset into one dataset called `ceqr_school_buildings`. Because data packages were also changed to reflect these data updates in PR #632, this PR includes changes to how we access metadata throughout the frontend.

### Changes:
- `public-schools-analysis` model
- `table-existing-conditions` component
- `existing-conditions-steps` component
- `public-schools/summary` component
- `recently-built-schools` component
- `school` fragment
- `school` fragment unit test
- `public-schools-analysis` mirage factory
- `public-schools-analysis` model unit test 

Addresses #630 