### PR TITLE
627 Add dockerized script to fetch & transform 2018 ACS data

### DIFF
--- a/data/acs/README.md
+++ b/data/acs/README.md
@@ -1,0 +1,23 @@
+# ACS Data Pipeline
+
+This folder (`/data/acs`) contains Python scripts to download and load 2018 ACS data into the CEQR database. This pipeline will likely be transferred to @NYCPlanning/EDM for ownership for future years.
+
+There is an accompanying Docker image file (`download/Dockerfile`) and `download/requirements.txt` file here to support containerized execution of the Python scripts.
+
+# Quickstart
+```
+yarn run download-acs-data
+```
+
+The Python scripts in this folder can be executed using the following predefined `package.json` script commands.
+
+**yarn download-acs-data**
+
+This command will generate the `nyc_acs.csv` file inside `/data/acs/download/output`
+
+To do so, it executes four steps:
+  1. Builds the Docker image defined by `/data/acs/download/Dockerfile`. When run, this image will download necessary Python libraries and then execute the `/data/acs/download/01_download.py` Python script.
+    - `01_download.py` will fetch 2018 ACS data from the Census' REST API, and transform the ACS data into the schema expected by the CEQR database's `nyc_acs` table.
+  2. Runs a Docker container that references the built image.
+  3. Copies generated csv file from inside container to the (host machine's) `/data/acs/download/output` folder.
+  4. Removes the container.

--- a/data/acs/download/01_download.py
+++ b/data/acs/download/01_download.py
@@ -1,0 +1,128 @@
+import requests
+import pandas as pd
+import json
+
+TRANSPORTATION_GROUP_ID = 'B08301'
+TRANSPORTATION_MODE_CONSTANT_MAP = {
+    'B08301_001': 'trans_total',
+    'B08301_002': 'trans_auto_total',
+    'B08301_003': 'trans_auto_solo',
+    'B08301_004': 'trans_auto_carpool_total',
+    'B08301_005': 'trans_auto_2',
+    'B08301_006': 'trans_auto_3',
+    'B08301_007': 'trans_auto_4',
+    'B08301_008': 'trans_auto_5_or_6',
+    'B08301_009': 'trans_auto_7_or_more',
+    'B08301_010': 'trans_public_total',
+    'B08301_011': 'trans_public_bus',
+    'B08301_012': 'trans_public_streetcar',
+    'B08301_013': 'trans_public_subway',
+    'B08301_014': 'trans_public_rail',
+    'B08301_015': 'trans_public_ferry',
+    'B08301_016': 'trans_taxi',
+    'B08301_017': 'trans_motorcycle',
+    'B08301_018': 'trans_bicycle',
+    'B08301_019': 'trans_walk',
+    'B08301_020': 'trans_other',
+    'B08301_021': 'trans_home'
+}
+
+POPULATION_GROUP_ID = 'B01003'
+POPULATION_TOTAL_ESTIMATE = 'B01003_001E'
+POPULATION_TOTAL_MARGIN_OF_ERROR = 'B01003_001M'
+
+# This function is adapted from EDM's db-acs/01_download.py file
+# Thank you, @NYCPlanning/EDM :)
+def get_tract(group):
+    '''
+    Downloads requested tract-level table for the five
+    NYC counties and combines into a single table
+    Parameters
+    ----------
+    group: str
+    Returns
+    -------
+    pd DataFrame
+        Contains data from requested ACS 5-year table,
+        all five NYC counties included
+    '''
+    frames = []
+    # Download tract-level tables using census API, and combine into a single NYC DataFrame
+    for county in ['081', '085', '005', '047', '061']:
+        url = f'https://api.census.gov/data/2018/acs/acs5?get=group({group})&for=tract:*&in=state:36&in=county:{county}'
+        resp = requests.request('GET', url).content
+        df = pd.DataFrame(json.loads(resp)[1:])
+        df.columns = json.loads(resp)[0]
+        frames.append(df)
+    return pd.concat(frames)
+
+if __name__ == "__main__":
+    # get tract-level data for all attributes in the B08301 "Means of Transportation" table
+    # For attribute info, see
+    # https://api.census.gov/data/2018/acs/acs5/groups/B08301.html
+    print("Downloading transportation census data...")
+    transportationData = get_tract(TRANSPORTATION_GROUP_ID)
+    
+
+    # get tract-level data for all attributes in the B01003 "Population" table
+    # For attribute info, see 
+    # https://api.census.gov/data/2018/acs/acs5/groups/B01003.html
+    print("Downloading population census data...")
+    populationData = get_tract(POPULATION_GROUP_ID)
+
+    print("Transforming data...")
+
+    # Add 'variable' column to transportation table, to match transportation and final output tables
+    transportationData['variable'] = pd.Series('to be replaced', index=transportationData.index)
+
+    nyc_acs_transportation = pd.DataFrame(columns=['geoid', 'value', 'moe', 'variable'])
+
+    # To represent the variables B08301_001...B08301_021
+    variableIds = range(1, 22)
+
+    # Flatten out the Means of Transportation table by representing Modes as rows instead of columns
+    # (Create a row for each Geoid - Mode combination)
+    for variableId in variableIds:
+        if variableId > 9:
+            modePrefix = 'B08301_0'
+        else:
+            modePrefix = 'B08301_00'
+        
+        modeCode = modePrefix + str(variableId)
+
+        variable_df = pd.DataFrame(
+            data=transportationData.loc[:, ['GEO_ID', modeCode + 'E', modeCode + 'M', 'variable']].values,
+            columns=['geoid', 'value', 'moe', 'variable']
+        )
+
+        # Replace 'to be replaced' values in the 'variable' column with Mode code
+        variable_df['variable'] = modeCode
+        
+        nyc_acs_transportation = pd.concat([nyc_acs_transportation, variable_df], ignore_index=True)
+
+    # replace ACS mode codes with CEQR mode constants
+    # Attribute codes taken from
+    # https://api.census.gov/data/2018/acs/acs5/groups/B08301.html
+    nyc_acs_transportation.replace(to_replace=TRANSPORTATION_MODE_CONSTANT_MAP, inplace=True)
+
+    # Add 'variable' column to population table, to match transportation and final output tables
+    populationData['variable'] = pd.Series('population', index=populationData.index)
+
+    nyc_acs_population = pd.DataFrame(
+            # grab the GEO_ID, Total Estimate (B01003_001E), Total Margin of Error (B01003_001M), and `variable` columns
+            data=populationData.loc[:, ['GEO_ID', POPULATION_TOTAL_ESTIMATE, POPULATION_TOTAL_MARGIN_OF_ERROR, 'variable']].values,
+            columns=['geoid', 'value', 'moe', 'variable']
+        )
+
+    # combine the flattened Means of Transportation and Population tables
+    # where possible values for 'census variable' are 'population' and also
+    # every attribute in the B08301 Means of Transportation table
+    nyc_acs = pd.concat([nyc_acs_transportation, nyc_acs_population])
+
+    print("Formatting geoids...")
+    # Remove '1400000US' prefix from geoid values
+    nyc_acs.replace(to_replace='1400000US', value='', regex=True, inplace=True)
+
+    nyc_acs.to_csv(f'./output/nyc_acs.csv', index=False)    
+
+    print("Success downloading and transforming NYC tract-level transportation and population data.")

--- a/data/acs/download/Dockerfile
+++ b/data/acs/download/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./01_download.py" ]

--- a/data/acs/download/requirements.txt
+++ b/data/acs/download/requirements.txt
@@ -1,0 +1,2 @@
+pandas==0.25.1
+requests==2.22.0

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "serve-rails": "cd backend && rails s",
     "serve-ember": "cd frontend && HOST='localhost:3000' ember s",
-    "serve": "concurrently 'npm:serve-*'"
+    "serve": "concurrently 'npm:serve-*'",
+    "download-acs-data": "mkdir -p ./data/acs/download/output && docker build -t acsdata ./data/acs/download && docker run --name acsdatacontain acsdata && yarn export-acs-data && docker rm acsdatacontain",
+    "export-acs-data": "docker cp acsdatacontain:/usr/src/app/output/nyc_acs.csv ./data/acs/download/output/nyc_acs.csv"
   }
 }


### PR DESCRIPTION
This PR is part of a series of PRs addressing https://github.com/NYCPlanning/ceqr-app/issues/627 (see that issue for the game plan)

This PR introduces a command to download 2018 ACS data,
transformed into the schema of the nyc_acs table, as a CSV.

It uses a Python script to do so, and uses Docker to support
running the Python script in a controlled environment.

The Python script was a rework of the script previously created to fetch 
2017 ACS data: https://github.com/NYCPlanning/db-ceqr-acs/blob/master/2017/ACS%20Merge.ipynb

Note that future commits will introduce commands and scripts
to load the CSV data into the CEQR database.