### PR TITLE
627 Add dockerized script to load 2018 ACS data into CEQR db

### DIFF
--- a/data/acs/README.md
+++ b/data/acs/README.md
@@ -2,22 +2,51 @@
 
 This folder (`/data/acs`) contains Python scripts to download and load 2018 ACS data into the CEQR database. This pipeline will likely be transferred to @NYCPlanning/EDM for ownership for future years.
 
-There is an accompanying Docker image file (`download/Dockerfile`) and `download/requirements.txt` file here to support containerized execution of the Python scripts.
+There are accompanying Docker image files and requirement.txt files in the `download/` and `load/` subfolders to support containerized execution of the Python scripts.
 
 # Quickstart
+
+Under the `/data/acs/load/` folder, Create an `.env` file with only the `CEQR_DATA_URL` variable:
+
+**/data/acs/load/.env:**
+```
+CEQR_DATA_URL=postgres://postgres@host.docker.internal:5432/ceqr_data-test
+```
+
+The value of `CEQR_DATA_URL` should be assigned a [postgres connection url](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) to the production or development/testing `ceqr_data` database.
+
+The example URL above assumes that there is a local PostGres database running on your local machine. Since `CEQR_DATA_URL` will be used by the Dockerized `load/02_dataloading.py` Python script, the `host.docker.internal` is used by the script to reach outside of the container and connect to the host machine's PostGres DB.
+
+Then, run the following two commands somewhere within this application's directory.
+
 ```
 yarn run download-acs-data
+yarn run load-acs-data
 ```
 
-The Python scripts in this folder can be executed using the following predefined `package.json` script commands.
+The above two commands are predefined `package.json` scripts. They will execute the Python scripts in this folder. Read more about each one below.
 
-**yarn download-acs-data**
+---
 
-This command will generate the `nyc_acs.csv` file inside `/data/acs/download/output`
+**yarn run download-acs-data**
+
+This command will generate the `nyc_acs.csv` file inside `/data/acs/download/output`.
 
 To do so, it executes four steps:
   1. Builds the Docker image defined by `/data/acs/download/Dockerfile`. When run, this image will download necessary Python libraries and then execute the `/data/acs/download/01_download.py` Python script.
-    - `01_download.py` will fetch 2018 ACS data from the Census' REST API, and transform the ACS data into the schema expected by the CEQR database's `nyc_acs` table.
+      - `01_download.py` will fetch 2018 ACS data from the Census' REST API, and transform the ACS data into the schema expected by the CEQR database's `nyc_acs` table.
   2. Runs a Docker container that references the built image.
   3. Copies generated csv file from inside container to the (host machine's) `/data/acs/download/output` folder.
+  4. Removes the container.
+
+**yarn run load-acs-data**
+
+This command will load the generated `nyc_acs.csv` file into the database and table specified by the `CEQR_DATA_URL` environment variable.
+
+To do so, it executes four steps:
+
+  1. Move the `nyc_acs.csv` file from `/data/acs/download/output` to `/data/acs/load`.
+  2. Builds the Docker image defined by `/data/acs/load/Dockerfile`. When run, this image will copy `nyc_acs.csv` into the parent container, download necessary Python libraries and then execute the `/data/acs/download/02_dataloading.py` Python script.
+  2. Runs a Docker container that references the built image.
+  3. From within the container, `02_dataloading.py` will connect to the `CEQR_DATA_URL` database, create the `nyc_acs.2018` table if it doesn't yet exist, and write `nyc_acs.csv` to that table.
   4. Removes the container.

--- a/data/acs/download/01_download.py
+++ b/data/acs/download/01_download.py
@@ -123,6 +123,6 @@ if __name__ == "__main__":
     # Remove '1400000US' prefix from geoid values
     nyc_acs.replace(to_replace='1400000US', value='', regex=True, inplace=True)
 
-    nyc_acs.to_csv(f'./output/nyc_acs.csv', index=False)    
+    nyc_acs.to_csv(f'./output/nyc_acs.csv', index=False)
 
     print("Success downloading and transforming NYC tract-level transportation and population data.")

--- a/data/acs/load/02_dataloading.py
+++ b/data/acs/load/02_dataloading.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import psycopg2
+from sqlalchemy import create_engine
+from pathlib import Path
+from dotenv import load_dotenv, find_dotenv
+import io
+import os
+from urllib.parse import urlparse
+
+def psycopg2_connect(url):
+    result = urlparse(str(url))
+    username = result.username
+    password = result.password
+    database = result.path[1:]
+    hostname = result.hostname
+    port = result.port
+    connection = psycopg2.connect(
+        database = database,
+        user = username,
+        password = password,
+        host = hostname, 
+        port = port)
+    return connection
+
+def load_acs_csv(year, path, con):
+    '''
+        Creates nyc_acs version table for specified `year`
+        
+        Parameters
+        ----------
+        year: str
+            '2017', '2018'
+        path: str
+            relative path to csv
+        con:
+            SQLAlchemy connection Engine
+    '''
+    df = pd.read_csv(path, index_col=False, dtype=str)
+
+    db_connection = psycopg2_connect(con.url)
+    db_cursor = db_connection.cursor()
+    str_buffer = io.StringIO()
+
+    df.to_csv(str_buffer, sep='\t', header=True, index=False)
+    str_buffer.seek(0)
+
+    con.execute(f'CREATE SCHEMA IF NOT EXISTS nyc_acs;')
+    con.execute(f'''
+        DROP TABLE IF EXISTS nyc_acs."{year}";
+        CREATE TABLE nyc_acs."{year}" (
+            geoid text,
+            value integer,
+            moe integer,
+            variable text
+        );
+    ''')
+
+    db_cursor.copy_expert(f'''COPY nyc_acs."{year}" FROM STDIN WITH NULL AS '' DELIMITER E'\t' CSV HEADER''', str_buffer)
+    db_cursor.connection.commit()
+    str_buffer.close()
+    db_cursor.close()
+    db_connection.close()
+
+if __name__ == "__main__":
+    load_dotenv(Path(__file__).parent/'.env')
+
+    print("Loading nyc_acs.csv into nyc_acs.2018...")
+
+    con = create_engine(os.getenv('CEQR_DATA_URL'))
+
+    load_acs_csv('2018', 'nyc_acs.csv', con)
+
+    print("Finished loading nyc_acs.csv into nyc_acs.2018")
+    

--- a/data/acs/load/Dockerfile
+++ b/data/acs/load/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./02_dataloading.py" ]

--- a/data/acs/load/requirements.txt
+++ b/data/acs/load/requirements.txt
@@ -1,0 +1,6 @@
+pandas==0.25.1
+psycopg2-binary==2.8.3
+python-dotenv==0.10.3
+requests==2.22.0
+SQLAlchemy==1.3.8
+urllib3==1.25.3

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "serve-ember": "cd frontend && HOST='localhost:3000' ember s",
     "serve": "concurrently 'npm:serve-*'",
     "download-acs-data": "mkdir -p ./data/acs/download/output && docker build -t acsdata ./data/acs/download && docker run --name acsdatacontain acsdata && yarn export-acs-data && docker rm acsdatacontain",
-    "export-acs-data": "docker cp acsdatacontain:/usr/src/app/output/nyc_acs.csv ./data/acs/download/output/nyc_acs.csv"
+    "export-acs-data": "docker cp acsdatacontain:/usr/src/app/output/nyc_acs.csv ./data/acs/download/output/nyc_acs.csv",
+    "load-acs-data": "mv ./data/acs/download/output/nyc_acs.csv ./data/acs/load/nyc_acs.csv && docker build -t loadacsdata ./data/acs/load && docker run --name loadacsdatacontain loadacsdata && docker rm loadacsdatacontain"
   }
 }


### PR DESCRIPTION
This PR is part of a series of PRs addressing #627 (see that issue for the game plan)

This PR introduces a command, `yarn run load-acs-data`, to load
a csv into the ceqr_data db's nyc_acs.2018 table. The csv
should be generated by the `yarn download-acs-data` command.

The command executes a Python script to facilitate connecting
to a DB and loading the table. Docker is used to run the script
in a controlled environment.

Though the two *-acs-data commands and scripts are written to
specifically download and load 2018 data, the code can be
tweaked for loading data for future years, assuming the
ACS REST API and CEQR nyc_acs schema stay unchanged.