### PR TITLE
659 Hotfix to defer loading of Public Schools Analysis subdistrict geometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # Ignore .env
 .env
 node_modules
+
+
+*.fixturesql

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -34,3 +34,6 @@
 # Ignore test coverage
 /coverage
 test.lock
+
+/dump
+*.fixturesql

--- a/backend/app/controllers/api/v1/subdistricts_geojsons_controller.rb
+++ b/backend/app/controllers/api/v1/subdistricts_geojsons_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::SubdistrictsGeojsonsController < ApiController
+end

--- a/backend/app/models/public_schools_analysis.rb
+++ b/backend/app/models/public_schools_analysis.rb
@@ -1,11 +1,13 @@
 class PublicSchoolsAnalysis < ApplicationRecord
   before_create :compute_for_project_create_or_update
+  after_create :create_subdistricts_geojson!
   
   before_update :compute_for_project_create_or_update,
     if: Proc.new { data_package_id_changed? || subdistricts_from_user_changed? }
 
   belongs_to :project
   belongs_to :data_package
+  has_one :subdistricts_geojson, dependent: :destroy
 
   def compute_for_updated_bbls!
     compute_for_project_create_or_update
@@ -21,6 +23,10 @@ class PublicSchoolsAnalysis < ApplicationRecord
   end
 
   private
+
+  def create_subdistricts_geojson!
+    create_subdistricts_geojson
+  end
 
   def compute_for_project_create_or_update
     set_subdistricts_from_db

--- a/backend/app/models/subdistricts_geojson.rb
+++ b/backend/app/models/subdistricts_geojson.rb
@@ -1,0 +1,3 @@
+class SubdistrictsGeojson < ApplicationRecord
+  has_one :public_schools_analysis
+end

--- a/backend/app/policies/subdistricts_geojson_policy.rb
+++ b/backend/app/policies/subdistricts_geojson_policy.rb
@@ -1,0 +1,9 @@
+class SubdistrictsGeojsonPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+end

--- a/backend/app/resources/api/v1/public_schools_analysis_resource.rb
+++ b/backend/app/resources/api/v1/public_schools_analysis_resource.rb
@@ -26,13 +26,11 @@ module Api
         :sca_projects,
     
         :doe_util_changes,
-    
-        # computed geojson
-        :subdistricts_geojson
       )
     
       has_one :project
       has_one :data_package
+      has_one :subdistricts_geojson
       
       def multipliers
         multiplier_version = data_package.version == "november_2017" ? "march-2014" : "november-2018"
@@ -45,16 +43,7 @@ module Api
       def new_data_available
         DataPackage.latest_for('public_schools').id != data_package.id
       end
-    
-      def subdistricts_geojson    
-        RGeo::GeoJSON.encode(
-          RGeo::GeoJSON::FeatureCollection.new(  
-            @model.subdistricts.map do |sd|
-              RGeo::GeoJSON::Feature.new(sd[:geom])
-            end
-          )
-        )
-      end
+
     end
   end
 end

--- a/backend/app/resources/api/v1/subdistricts_geojson_resource.rb
+++ b/backend/app/resources/api/v1/subdistricts_geojson_resource.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class SubdistrictsGeojsonResource < BaseResource
+      attributes(
+        # computed geojson
+        :subdistricts_geojson,
+      )
+
+      has_one :public_schools_analysis
+    
+      def subdistricts_geojson
+        RGeo::GeoJSON.encode(
+          RGeo::GeoJSON::FeatureCollection.new(
+            @model.public_schools_analysis.subdistricts.map do |sd|
+              RGeo::GeoJSON::Feature.new(sd[:geom])
+            end
+          )
+        )
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       jsonapi_resources :data_packages
 
       # Analyses
+      jsonapi_resources :subdistricts_geojsons
       jsonapi_resources :public_schools_analyses
       jsonapi_resources :transportation_analyses
       jsonapi_resources :transportation_planning_factors

--- a/backend/db/migrate/20200306194629_create_subdistricts_geojsons.rb
+++ b/backend/db/migrate/20200306194629_create_subdistricts_geojsons.rb
@@ -1,0 +1,9 @@
+class CreateSubdistrictsGeojsons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :subdistricts_geojsons do |t|
+      t.integer :public_schools_analysis_id
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20200306194630_add_subdistricts_geojson_belongs_to_to_public_schools_analysis.rb
+++ b/backend/db/migrate/20200306194630_add_subdistricts_geojson_belongs_to_to_public_schools_analysis.rb
@@ -1,0 +1,5 @@
+class AddSubdistrictsGeojsonBelongsToToPublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :public_schools_analyses, :subdistricts_geojson, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_28_172244) do
+ActiveRecord::Schema.define(version: 2020_03_06_194630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -81,7 +81,15 @@ ActiveRecord::Schema.define(version: 2020_02_28_172244) do
     t.datetime "updated_at", null: false
     t.integer "project_id"
     t.bigint "data_package_id"
+    t.bigint "subdistricts_geojson_id"
     t.index ["data_package_id"], name: "index_public_schools_analyses_on_data_package_id"
+    t.index ["subdistricts_geojson_id"], name: "index_public_schools_analyses_on_subdistricts_geojson_id"
+  end
+
+  create_table "subdistricts_geojsons", force: :cascade do |t|
+    t.integer "public_schools_analysis_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "transportation_analyses", force: :cascade do |t|
@@ -127,6 +135,7 @@ ActiveRecord::Schema.define(version: 2020_02_28_172244) do
   add_foreign_key "projects", "data_packages"
   add_foreign_key "public_schools_analyses", "data_packages"
   add_foreign_key "public_schools_analyses", "projects"
+  add_foreign_key "public_schools_analyses", "subdistricts_geojsons"
   add_foreign_key "transportation_analyses", "projects"
   add_foreign_key "transportation_planning_factors", "data_packages"
   add_foreign_key "transportation_planning_factors", "transportation_analyses"

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -227,3 +227,9 @@ if DataPackage.where(package: "mappluto", version: "19v1").first.nil?
     }
   })
 end
+
+if SubdistrictsGeojson.first.nil?
+  PublicSchoolsAnalysis.all.each do |analysis|
+    SubdistrictsGeojson.create(public_schools_analysis_id: analysis.id)
+  end
+end

--- a/backend/spec/factories/subdistricts_geojsons.rb
+++ b/backend/spec/factories/subdistricts_geojsons.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :subdistricts_geojson do
+    public_schools_analysis_id { 1 }
+  end
+end

--- a/frontend/app/components/public-schools/project-map.js
+++ b/frontend/app/components/public-schools/project-map.js
@@ -148,7 +148,7 @@ export default Component.extend({
       map.addControl(nav, 'top-right');
 
       this.set('mapservice.map', map);
-      this.get('mapservice').fitToSubdistricts(this.analysis.subdistrictsGeojson);
+      this.get('mapservice').fitToSubdistricts(this.subdistrictsGeojson);
 
       this.set('map', map);
     },

--- a/frontend/app/models/public-schools-analysis.js
+++ b/frontend/app/models/public-schools-analysis.js
@@ -73,7 +73,8 @@ export default DS.Model.extend({
   // School District & Subdistricts
   subdistrictsFromDb: DS.attr('', { defaultValue() { return []; } }),
   subdistrictsFromUser: DS.attr('', { defaultValue() { return []; } }),
-  subdistrictsGeojson: DS.attr(''),
+  subdistrictsGeojson: DS.belongsTo('subdistricts-geojson'),
+  
 
   subdistricts: computed('subdistrictsFromDb.@each', 'subdistrictsFromUser.@each', function() {
     return this.subdistrictsFromDb.concat(this.subdistrictsFromUser);

--- a/frontend/app/models/subdistricts-geojson.js
+++ b/frontend/app/models/subdistricts-geojson.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+const { Model } = DS;
+import { attr } from '@ember-decorators/data';
+
+export default class SubdistrictsGeojsonModel extends Model {
+  @attr('') subdistrictsGeojson;
+}

--- a/frontend/app/serializers/public-schools-analysis.js
+++ b/frontend/app/serializers/public-schools-analysis.js
@@ -5,6 +5,5 @@ export default class PublicSchoolsAnalysisSerializer extends JSONAPISerializer {
   attrs = {
     newDataAvailable:  { serialize: false },
     multipliers:  { serialize: false },
-    subdistrictsGeojson: { serialize: false }
   }
 }

--- a/frontend/app/serializers/subdistricts-geojson.js
+++ b/frontend/app/serializers/subdistricts-geojson.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+const { JSONAPISerializer } = DS;
+
+export default class SubdistrictsGeojsonSerializer extends JSONAPISerializer {
+  attrs = {
+    subdistrictsGeojson: { serialize: false }
+  }
+}

--- a/frontend/app/templates/components/public-schools/project-map.hbs
+++ b/frontend/app/templates/components/public-schools/project-map.hbs
@@ -98,7 +98,7 @@
     </div>
   </div>
   <map.source
-    @options={{hash type="geojson" data=project.publicSchoolsAnalysis.subdistrictsGeojson}} as |source|
+    @options={{hash type="geojson" data=subdistrictsGeojson}} as |source|
   >
     <source.layer
       @layer={{hash

--- a/frontend/app/templates/project/show/public-schools.hbs
+++ b/frontend/app/templates/project/show/public-schools.hbs
@@ -33,17 +33,27 @@
       </div>
     </div>
   </div>
+{{/if}}
 
-  {{#if (and showMap project-orchestrator.projectTask.isIdle)}}
-    <div class="row">
-      <div class="sixteen wide column">
-        <PublicSchools::ProjectMap
-          @project={{model.project}}
-          @analysis={{model.publicSchoolsAnalysis}}
-        />
-      </div>
+{{#if (and showMap project-orchestrator.projectTask.isIdle)}}
+  <div class="row">
+    <div class="sixteen wide column">
+      {{#with model.publicSchoolsAnalysis.subdistrictsGeojson.subdistrictsGeojson as |subdistricts|}}
+          <PublicSchools::ProjectMap
+            @project={{model.project}}
+            @analysis={{model.publicSchoolsAnalysis}}
+            @subdistrictsGeojson={{subdistricts}}
+          />
+      {{/with}}
+      {{#unless model.publicSchoolsAnalysis.subdistrictsGeojson.subdistrictsGeojson}}
+          <div style="height: 100px; background-color: #CCE2FF">
+            <div class="ui active inverted dimmer">
+              <div class="ui text loader">Loading map of subdistricts... Please wait... </div>
+            </div>
+          </div>
+      {{/unless}}
     </div>
-  {{/if}}
+  </div>
 {{/if}}
 
 {{#if project-orchestrator.projectTask.isIdle}}


### PR DESCRIPTION
### About 
This Hotfix solves latency in opening and editing projects. It does so by deferring loading of
Public Schools Analysis' subdistricts_geojson attribute. That attribute requires the backend
to compute subdistrict geometries by querying the Mappluto table, which turns out to be a slow
computation. Previously, the app loaded this attribute when a user clicks to open a project.
Now, this attribute only loads when the maps load on the Existing Conditions or No Action
steps of the analysis. It introduces a loading spinner to the UI to indicate the subdistrict
map is loading.

The approach taken is to break out the `subdistricts_geojson` attribute into its own entity, so that it will not be sideloaded along with the Public Schools Analysis entity. Routes such as `project/show` and `project/show/public-schools` are set up to load both the Project and Public Schools Analysis models entirely, meaning every attribute. By breaking Subdistricts Geojson into its own model, we can deliberately load it at later (deeper nested) route.

### Deployment

1.  Deploy/merge to a staging preview 
On staging ceqr_rails...
2. `rails db:migrate` in order to generate the new subdistricts_geojson table.
3. `rails db:seed` in order to populate the new subdistricts_geojson table.
4. Repeat for Master

### Considerations
The new `subdistricts_geojson` table may not be the most ideal approach, because the table exists simply to support a "virtual" model in both Rails and Ember.
However, in the future it may be good to store precomputed subdistrict geojson in these tables to speed up load times. 