### PR TITLE
Disable site maintenance popup notice 

### DIFF
--- a/frontend/app/templates/application.hbs
+++ b/frontend/app/templates/application.hbs
@@ -9,7 +9,7 @@
     @dismissible - boolean: allows user to close message
   --}}
   {{site-message
-    message="We are currently experiencing platform stability problems. Engineers are working on a resolution. Please try again later."
+    message=false
     warning=true
     dismissible=true
   }}


### PR DESCRIPTION
Taking down the message after issues with project loading and editing (#659 ) have been resolved via PRs (#666 and #663 )