### PR TITLE
659: Only load subdistricts when at Public Schools Analysis Existing Conditions Step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # Ignore .env
 .env
 node_modules
+
+
+*.fixturesql

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -93,6 +93,15 @@ SSH into the backend docker container `docker exec -it ceqr-app_backend_1 /bin/b
 
 Once inside the container, run the rails migration command `rails generate migration name_of_your_migration`
 
+**For running the migrations in the Heroku UI:**
+
+Navigate to the ceqr-app on the Labs Heroku account. Select the environment (e.g. staging) that you would like to run the migrations on. On the top right of the page, you will see a button that says "More". Click on this button and select "Run Console" from the dropdown menu. Type `bash` into the console and hit "Run". 
+
+In order to run the migrations: `rails db:migrate`
+
+If you created a new table and need to populate this table with data after running the migrations: 
+`rails db:seed`
+
 ### Debugging
 You can enter the running rails application by running:
 ```sh

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -34,3 +34,6 @@
 # Ignore test coverage
 /coverage
 test.lock
+
+/dump
+*.fixturesql

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,5 +9,7 @@ When creating a `review` app from a Pull Request, there are a few manual bootstr
     ```sh
     $ heroku run -a ceqr-app-staging-pr-XXX rails db:migrate
     ```
+    You can also run these migrations on the Heroku UI. For instructions visit the DOCKER.md file and look
+    under the "Creating and Running Migrations in Docker Container" section.
 3. Set `HOST_PR_REVIEW` on netlify with the heroku app's hostname.
     - This is necessary to get the frontend talking to the backend

--- a/backend/app/controllers/api/v1/subdistricts_geojsons_controller.rb
+++ b/backend/app/controllers/api/v1/subdistricts_geojsons_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::SubdistrictsGeojsonsController < ApiController
+end

--- a/backend/app/models/public_schools_analysis.rb
+++ b/backend/app/models/public_schools_analysis.rb
@@ -1,11 +1,13 @@
 class PublicSchoolsAnalysis < ApplicationRecord
   before_create :compute_for_project_create_or_update
+  after_create :create_subdistricts_geojson!
   
   before_update :compute_for_project_create_or_update,
     if: Proc.new { data_package_id_changed? || subdistricts_from_user_changed? }
 
   belongs_to :project
   belongs_to :data_package
+  has_one :subdistricts_geojson, dependent: :destroy
 
   def compute_for_updated_bbls!
     compute_for_project_create_or_update
@@ -21,6 +23,10 @@ class PublicSchoolsAnalysis < ApplicationRecord
   end
 
   private
+
+  def create_subdistricts_geojson!
+    create_subdistricts_geojson
+  end
 
   def compute_for_project_create_or_update
     set_subdistricts_from_db

--- a/backend/app/models/subdistricts_geojson.rb
+++ b/backend/app/models/subdistricts_geojson.rb
@@ -1,0 +1,3 @@
+class SubdistrictsGeojson < ApplicationRecord
+  has_one :public_schools_analysis
+end

--- a/backend/app/policies/subdistricts_geojson_policy.rb
+++ b/backend/app/policies/subdistricts_geojson_policy.rb
@@ -1,0 +1,9 @@
+class SubdistrictsGeojsonPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+end

--- a/backend/app/resources/api/v1/public_schools_analysis_resource.rb
+++ b/backend/app/resources/api/v1/public_schools_analysis_resource.rb
@@ -26,13 +26,11 @@ module Api
         :sca_projects,
     
         :doe_util_changes,
-    
-        # computed geojson
-        :subdistricts_geojson
       )
     
       has_one :project
       has_one :data_package
+      has_one :subdistricts_geojson
       
       def multipliers
         multiplier_version = data_package.version == "november_2017" ? "march-2014" : "november-2018"
@@ -44,16 +42,6 @@ module Api
     
       def new_data_available
         DataPackage.latest_for('public_schools').id != data_package.id
-      end
-    
-      def subdistricts_geojson    
-        RGeo::GeoJSON.encode(
-          RGeo::GeoJSON::FeatureCollection.new(  
-            @model.subdistricts.map do |sd|
-              RGeo::GeoJSON::Feature.new(sd[:geom])
-            end
-          )
-        )
       end
     end
   end

--- a/backend/app/resources/api/v1/subdistricts_geojson_resource.rb
+++ b/backend/app/resources/api/v1/subdistricts_geojson_resource.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class SubdistrictsGeojsonResource < BaseResource
+      attributes(
+        # computed geojson
+        :subdistricts_geojson,
+      )
+
+      has_one :public_schools_analysis
+
+      def subdistricts_geojson
+        RGeo::GeoJSON.encode(
+          RGeo::GeoJSON::FeatureCollection.new(
+            @model.public_schools_analysis.subdistricts.map do |sd|
+              RGeo::GeoJSON::Feature.new(sd[:geom])
+            end
+          )
+        )
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       jsonapi_resources :data_packages
 
       # Analyses
+      jsonapi_resources :subdistricts_geojsons
       jsonapi_resources :public_schools_analyses
       jsonapi_resources :transportation_analyses
       jsonapi_resources :transportation_planning_factors

--- a/backend/db/migrate/20200317152657_create_subdistricts_geojsons.rb
+++ b/backend/db/migrate/20200317152657_create_subdistricts_geojsons.rb
@@ -1,0 +1,9 @@
+class CreateSubdistrictsGeojsons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :subdistricts_geojsons do |t|
+      t.integer :public_schools_analysis_id
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20200317154318_add_subdistricts_geojson_belongs_to_to_public_schools_analysis.rb
+++ b/backend/db/migrate/20200317154318_add_subdistricts_geojson_belongs_to_to_public_schools_analysis.rb
@@ -1,0 +1,5 @@
+class AddSubdistrictsGeojsonBelongsToToPublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :public_schools_analyses, :subdistricts_geojson, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -81,7 +81,15 @@ ActiveRecord::Schema.define(version: 2020_03_17_165721) do
     t.datetime "updated_at", null: false
     t.integer "project_id"
     t.bigint "data_package_id"
+    t.bigint "subdistricts_geojson_id"
     t.index ["data_package_id"], name: "index_public_schools_analyses_on_data_package_id"
+    t.index ["subdistricts_geojson_id"], name: "index_public_schools_analyses_on_subdistricts_geojson_id"
+  end
+
+  create_table "subdistricts_geojsons", force: :cascade do |t|
+    t.integer "public_schools_analysis_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "transportation_analyses", force: :cascade do |t|
@@ -127,6 +135,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_165721) do
   add_foreign_key "projects", "data_packages"
   add_foreign_key "public_schools_analyses", "data_packages"
   add_foreign_key "public_schools_analyses", "projects"
+  add_foreign_key "public_schools_analyses", "subdistricts_geojsons"
   add_foreign_key "transportation_analyses", "projects"
   add_foreign_key "transportation_planning_factors", "data_packages"
   add_foreign_key "transportation_planning_factors", "transportation_analyses"

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -240,3 +240,9 @@ if DataPackage.where(package: "mappluto", version: "19v1").first.nil?
     }
   })
 end
+
+if SubdistrictsGeojson.first.nil?
+  PublicSchoolsAnalysis.all.each do |analysis|
+    SubdistrictsGeojson.create(public_schools_analysis_id: analysis.id)
+  end
+end

--- a/backend/spec/factories/subdistricts_geojsons.rb
+++ b/backend/spec/factories/subdistricts_geojsons.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :subdistricts_geojson do
+    public_schools_analysis_id { 1 }
+  end
+end

--- a/frontend/app/components/public-schools/project-map.js
+++ b/frontend/app/components/public-schools/project-map.js
@@ -148,7 +148,7 @@ export default Component.extend({
       map.addControl(nav, 'top-right');
 
       this.set('mapservice.map', map);
-      this.get('mapservice').fitToSubdistricts(this.analysis.subdistrictsGeojson);
+      this.get('mapservice').fitToSubdistricts(this.subdistrictsGeojson);
 
       this.set('map', map);
     },

--- a/frontend/app/models/public-schools-analysis.js
+++ b/frontend/app/models/public-schools-analysis.js
@@ -73,7 +73,7 @@ export default DS.Model.extend({
   // School District & Subdistricts
   subdistrictsFromDb: DS.attr('', { defaultValue() { return []; } }),
   subdistrictsFromUser: DS.attr('', { defaultValue() { return []; } }),
-  subdistrictsGeojson: DS.attr(''),
+  subdistrictsGeojson: DS.belongsTo('subdistricts-geojson'),
 
   subdistricts: computed('subdistrictsFromDb.@each', 'subdistrictsFromUser.@each', function() {
     return this.subdistrictsFromDb.concat(this.subdistrictsFromUser);

--- a/frontend/app/models/subdistricts-geojson.js
+++ b/frontend/app/models/subdistricts-geojson.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  publicSchoolsAnalysis: DS.belongsTo('public-schools-analysis'),
+
+  subdistrictsGeojson: DS.attr(''),
+});

--- a/frontend/app/serializers/public-schools-analysis.js
+++ b/frontend/app/serializers/public-schools-analysis.js
@@ -6,6 +6,5 @@ export default class PublicSchoolsAnalysisSerializer extends JSONAPISerializer {
   attrs = {
     newDataAvailable: { serialize: false },
     multipliers: { serialize: false },
-    subdistrictsGeojson: { serialize: false },
   }
 }

--- a/frontend/app/serializers/subdistricts-geojson.js
+++ b/frontend/app/serializers/subdistricts-geojson.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+const { JSONAPISerializer } = DS;
+
+export default class SubdistrictsGeojsonSerializer extends JSONAPISerializer {
+  attrs = {
+    subdistrictsGeojson: { serialize: false },
+  }
+}

--- a/frontend/app/templates/components/public-schools/project-map.hbs
+++ b/frontend/app/templates/components/public-schools/project-map.hbs
@@ -98,7 +98,7 @@
     </div>
   </div>
   <map.source
-    @options={{hash type="geojson" data=project.publicSchoolsAnalysis.subdistrictsGeojson}} as |source|
+    @options={{hash type="geojson" data=subdistrictsGeojson}} as |source|
   >
     <source.layer
       @layer={{hash

--- a/frontend/app/templates/project/show/public-schools.hbs
+++ b/frontend/app/templates/project/show/public-schools.hbs
@@ -33,17 +33,27 @@
       </div>
     </div>
   </div>
+{{/if}}
 
-  {{#if (and showMap project-orchestrator.projectTask.isIdle)}}
-    <div class="row">
-      <div class="sixteen wide column">
-        <PublicSchools::ProjectMap
-          @project={{model.project}}
-          @analysis={{model.publicSchoolsAnalysis}}
-        />
-      </div>
+{{#if (and showMap project-orchestrator.projectTask.isIdle)}}
+  <div class="row">
+    <div class="sixteen wide column">
+      {{#with model.publicSchoolsAnalysis.subdistrictsGeojson.subdistrictsGeojson as |subdistricts|}}
+          <PublicSchools::ProjectMap
+            @project={{model.project}}
+            @analysis={{model.publicSchoolsAnalysis}}
+            @subdistrictsGeojson={{subdistricts}}
+          />
+      {{/with}}
+      {{#unless model.publicSchoolsAnalysis.subdistrictsGeojson.subdistrictsGeojson}}
+          <div style="height: 100px; background-color: #CCE2FF">
+            <div class="ui active inverted dimmer">
+              <div class="ui text loader">Loading map of subdistricts... Please wait... </div>
+            </div>
+          </div>
+      {{/unless}}
     </div>
-  {{/if}}
+  </div>
 {{/if}}
 
 {{#if project-orchestrator.projectTask.isIdle}}

--- a/frontend/tests/unit/models/subdistricts-geojson-test.js
+++ b/frontend/tests/unit/models/subdistricts-geojson-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | subdistricts geojson', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('subdistricts-geojson', {});
+    assert.ok(model);
+  });
+});

--- a/frontend/tests/unit/serializers/subdistricts-geojson-test.js
+++ b/frontend/tests/unit/serializers/subdistricts-geojson-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | subdistricts geojson', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const serializer = store.serializerFor('subdistricts-geojson');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const record = store.createRecord('subdistricts-geojson', {});
+
+    const serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});


### PR DESCRIPTION
Addresses #659 

### About 
This Hotfix solves latency in opening and editing projects. It does so by deferring loading of
Public Schools Analysis' subdistricts_geojson attribute. That attribute requires the backend
to compute subdistrict geometries by querying the Mappluto table, which turns out to be a slow
computation. Previously, the app loaded this attribute when a user clicks to open a project.
Now, this attribute only loads when the maps load on the Existing Conditions or No Action
steps of the analysis. It introduces a loading spinner to the UI to indicate the subdistrict
map is loading.

The approach taken is to break out the `subdistricts_geojson` attribute into its own entity, so that it will not be sideloaded along with the Public Schools Analysis entity. Routes such as `project/show` and `project/show/public-schools` are set up to load both the Project and Public Schools Analysis models entirely, meaning every attribute. By breaking Subdistricts Geojson into its own model, we can deliberately load it at later (deeper nested) route.

### Deployment

1.  Deploy/merge to a staging preview 
On staging ceqr_rails...
2. `rails db:migrate` in order to generate the new subdistricts_geojson table.
3. `rails db:seed` in order to populate the new subdistricts_geojson table.
4. Repeat for Master

### Considerations
The new `subdistricts_geojson` table may not be the most ideal approach, because the table exists simply to support a "virtual" model in both Rails and Ember.
However, in the future it may be good to store precomputed subdistrict geojson in these tables to speed up load times. 