### PR TITLE
Fix circleci rails test database environment config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Specify service dependencies here if necessary # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/postgres:latest-postgis
+      - image: circleci/postgres:10.12-postgis
         environment:
           POSTGRES_USER: ceqr
           POSTGRES_DB: ceqr_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
         environment:
           POSTGRES_USER: ceqr
           POSTGRES_DB: ceqr_test
-          POSTGRES_PASSWORD: testingpassword
 
     working_directory: ~/repo/backend
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ jobs:
       - run:
           name: setup DB
           command: |
-            bundle exec rake --trace db:create
-            bundle exec rake --trace db:schema:load
+            bundle exec rake db:create
+            bundle exec rake db:schema:load
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # specify the version you desire here
       - image: circleci/ruby:2.6.4
         environment:
-          DATABASE_URL: postgis://ceqr@127.0.0.1/ceqr_test
+          DATABASE_URL: postgis://ceqr:testingpassword@127.0.0.1/ceqr_test
           JWT_SALT: TEST_RANDOM_KEY
           ADMIN_EMAILS: test@example.com
           SENDGRID_KEY: NOPE
@@ -20,6 +20,7 @@ jobs:
         environment:
           POSTGRES_USER: ceqr
           POSTGRES_DB: ceqr_test
+          POSTGRES_PASSWORD: testingpassword
 
     working_directory: ~/repo/backend
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - image: circleci/ruby:2.6.4
         environment:
           RAILS_ENV: test
-          DATABASE_URL: postgis://ceqr:testingpassword@127.0.0.1/ceqr_test
+          DATABASE_URL: postgres://ceqr:testingpassword@127.0.0.1/ceqr_test
           JWT_SALT: TEST_RANDOM_KEY
           ADMIN_EMAILS: test@example.com
           SENDGRID_KEY: NOPE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   rails_tests:
     docker:
       # specify the version you desire here
-      - image: cir  cleci/ruby:2.6.4
+      - image: circleci/ruby:2.6.4
         environment:
           RAILS_ENV: test
           DATABASE_URL: postgis://ceqr@127.0.0.1/ceqr_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
         environment:
           POSTGRES_USER: ceqr
           POSTGRES_DB: ceqr_test
+          POSTGRES_PASSWORD: testingpassword
 
     working_directory: ~/repo/backend
 
@@ -49,8 +50,8 @@ jobs:
       - run:
           name: setup DB
           command: |
-            bundle exec rake db:create
-            bundle exec rake db:schema:load
+            bundle exec rake --trace db:create
+            bundle exec rake --trace db:schema:load
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       # specify the version you desire here
       - image: circleci/ruby:2.6.4
         environment:
+          RAILS_ENV: test
           DATABASE_URL: postgis://ceqr:testingpassword@127.0.0.1/ceqr_test
           JWT_SALT: TEST_RANDOM_KEY
           ADMIN_EMAILS: test@example.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,7 @@ jobs:
       - image: cir  cleci/ruby:2.6.4
         environment:
           RAILS_ENV: test
-          DATABASE_URL: postgis://ceqr:testingpassword@127.0.0.1/ceqr_test
-          PGHOST: 127.0.0.1
-          PGUSER: ceqr
+          DATABASE_URL: postgis://ceqr@127.0.0.1/ceqr_test
           JWT_SALT: TEST_RANDOM_KEY
           ADMIN_EMAILS: test@example.com
           SENDGRID_KEY: NOPE
@@ -23,7 +21,6 @@ jobs:
         environment:
           POSTGRES_USER: ceqr
           POSTGRES_DB: ceqr_test
-          POSTGRES_PASSWORD: testingpassword
 
     working_directory: ~/repo/backend
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Specify service dependencies here if necessary # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/postgres:10.12-postgis
+      - image: circleci/postgres:9.6.2-alpine
         environment:
           POSTGRES_USER: ceqr
           POSTGRES_DB: ceqr_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,12 @@ jobs:
   rails_tests:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.6.4
+      - image: cir  cleci/ruby:2.6.4
         environment:
           RAILS_ENV: test
-          DATABASE_URL: postgres://ceqr:testingpassword@127.0.0.1/ceqr_test
+          DATABASE_URL: postgis://ceqr:testingpassword@127.0.0.1/ceqr_test
+          PGHOST: 127.0.0.1
+          PGUSER: ceqr
           JWT_SALT: TEST_RANDOM_KEY
           ADMIN_EMAILS: test@example.com
           SENDGRID_KEY: NOPE


### PR DESCRIPTION
This PR addresses #672 and fixes the postgres rails test container setup in CircleCI.

There was a breaking change to the postgres image which
stopped circleci's automated rails test to work.

See here:  https://discuss.circleci.com/t/postgres-just-stopped-working/34511

This commit adds the needed environment variable to allow the postgres
image to authenticate.