### PR TITLE
Add data disclaimer for public schools data update

### DIFF
--- a/frontend/app/templates/components/public-schools/analysis-threshold.hbs
+++ b/frontend/app/templates/components/public-schools/analysis-threshold.hbs
@@ -1,6 +1,19 @@
 <div class="ui grid">
   <div class="row" style="margin-top: 10px">
     <div class="sixteen wide column">
+
+      <div class="ui icon message">
+      <i class="ui huge red exclamation circle icon"></i>
+        <div class="content">
+          <div class="header">
+            Important Note about Public Schools Data
+          </div>
+          <p>
+            The CEQR Application's Public Schools analysis is currently being updated to reflect <a href="http://www.nycsca.org/community/capital-plan-reports-data" target="_blank" rel="noopener">newly-released data</a>. Please use the latest Public Schools analysis data until further notice. Thank you.
+          </p>
+        </div>
+      </div>
+
       <div
         class="ui {{if analysis.detailedAnalysis "yellow" "grey"}} segment"
       >


### PR DESCRIPTION
Disclaimer to notify users of outdated data while public schools data update is being implemented. This disclaimer will show up on the "Threshold Analysis" tab on the Public Schools Analysis.

<img width="1340" alt="Screen Shot 2020-03-23 at 5 36 39 PM" src="https://user-images.githubusercontent.com/26672885/77365670-e5d2af80-6d2c-11ea-97f4-c7f8590d8d3f.png">

