### PR TITLE
661 Fix password reset page by removing use of deprecated queryParams property

### DIFF
--- a/backend/app/views/user_mailer/password_reset.text.erb
+++ b/backend/app/views/user_mailer/password_reset.text.erb
@@ -3,6 +3,10 @@ CEQR App
 
 A request was sent to reset your password, if this was not you, please ignore this email.
 
-To reset your password, follow this link: 
+To reset your password, follow the link below. Please note that your email
+provider may reformat the link below for safety.
+
+Remove the word "BLOCKED" and any square brackets like "[" or "]" before
+pasting the link into your browser.
 
 <%= "#{@base_url}/password-reset?token=#{@token}" %>

--- a/frontend/app/routes/password-reset.js
+++ b/frontend/app/routes/password-reset.js
@@ -5,7 +5,7 @@ export default Route.extend({
   session: service(),
 
   beforeModel(transition) {
-    if (this.session.isAuthenticated || !transition.queryParams.token) {
+    if (this.session.isAuthenticated || !transition.to.queryParams.token) {
       this.transitionTo('index');
     }
   },

--- a/frontend/app/templates/components/password-reset-form.hbs
+++ b/frontend/app/templates/components/password-reset-form.hbs
@@ -1,4 +1,7 @@
-<div class="ui grid container">
+<div
+  class="ui grid container"
+  data-test-password-reset-form
+>
   <div class="six wide centered column">
     <h2 class="ui blue header">
       <div class="content">

--- a/frontend/tests/acceptance/user-can-visit-password-reset-test.js
+++ b/frontend/tests/acceptance/user-can-visit-password-reset-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { visit, find } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Acceptance | user can visit password reset', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('Unauthenticated user can visit password reset page with a token', async function(assert) {
+    this.server.create('user');
+
+    await visit('/password-reset?token=a-token');
+
+    assert.ok(find('[data-test-password-reset-form]'));
+  });
+});


### PR DESCRIPTION
Previously the route beforeModel hook hung when trying to access transition.queryParams.
That property is now deprecated. see emberjs/ember.js#18004

Instead, we now use `transition.to.queryParams`

This commit also adds instructions to the password reset email to
help users restore the reset link if it was reformated by the
email provider for security purposes.