### PR TITLE
Update the table name for the 2019 data package

### DIFF
--- a/backend/db/migrate/20200507154905_update_sca_capital_projects_data_package_2019_11.rb
+++ b/backend/db/migrate/20200507154905_update_sca_capital_projects_data_package_2019_11.rb
@@ -1,0 +1,21 @@
+class UpdateScaCapitalProjectsDataPackage201911 < ActiveRecord::Migration[5.2]
+  def up
+    dataPackage = DataPackage.find_by(name: 'November 2019')
+
+    schemas = dataPackage.schemas
+
+    schemas["sca_capacity_projects"]["table"] = "112019"
+
+    dataPackage.update(schemas: schemas)
+  end
+
+  def down
+    dataPackage = DataPackage.find_by(name: 'November 2019')
+
+    schemas = dataPackage.schemas
+
+    schemas["sca_capacity_projects"]["table"] = "022019"
+
+    dataPackage.update(schemas: schemas)
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_155341) do
+ActiveRecord::Schema.define(version: 2020_05_07_154905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"


### PR DESCRIPTION
This adds a migration which updates the specific sca_capacity_projects table to the latest one.
