### PR TITLE
Create new data package for November 2020

### DIFF
--- a/backend/db/migrate/20200507180402_add_data_package_november_2020_public_schools_analysis.rb
+++ b/backend/db/migrate/20200507180402_add_data_package_november_2020_public_schools_analysis.rb
@@ -1,0 +1,72 @@
+class AddDataPackageNovember2020PublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def up
+    DataPackage.create({
+      name: "November 2020",
+      version: "november_2020",
+      package: "public_schools",
+      release_date: Date.parse('2020-01-01'),
+      schemas: {
+        doe_school_zones_hs: {
+          table: "2019"
+        },
+        doe_school_zones_is: {
+          table: "2019"
+        },
+        doe_school_zones_ps: {
+          table: "2019"
+        },
+        ceqr_school_buildings: {
+          table: 2019,
+          sources: [
+            {
+              name: "lcgms",
+              maxYear: 2019,
+              minYear: 2018,
+              version: "2019-12-19"
+            },
+            {
+              name: "bluebook",
+              maxYear: 2018,
+              minYear: 2017
+            }
+          ]
+        },
+        sca_capacity_projects: {
+          table: "022020",
+          version: "2020-02-01"
+        },
+        doe_school_subdistricts: {
+          table: "2017"
+        },
+        sca_e_projections_by_sd: {
+          table: "2019",
+          maxYear: 2028,
+          minYear: 2018
+        },
+        sca_e_projections_by_boro: {
+          table: "2019",
+          maxYear: 2028,
+          minYear: 2018
+        },
+        sca_housing_pipeline_by_sd: {
+          table: "2019",
+          maxYear: 2027,
+          minYear: 2018
+        },
+        sca_housing_pipeline_by_boro: {
+          table: "2019",
+          maxYear: 2027,
+          minYear: 2018
+        },
+        doe_significant_utilization_changes: {
+          table: "072019",
+          version: "2019-07-01"
+        }
+      }
+    })
+  end
+
+  def down
+    DataPackage.find_by(name: "November 2020").destroy!
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_154905) do
+ActiveRecord::Schema.define(version: 2020_05_07_180402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"


### PR DESCRIPTION
New data package includes all the data from 2019 except for the SCA Capacity Projects update