### PR TITLE
11520 updated schema to allow for cascade delete on subdistricts_geojson column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@
 .env
 node_modules
 
+**/.DS_Store
+
+backend/logfile
+
 # optional database backup to load prod data into docker postgis
 backend/db/backup

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -37,3 +37,5 @@ test.lock
 
 /dump
 *.fixturesql
+
+**/.DS_Store

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2.1'
-gem 'pg'
+gem 'pg', '1.1.4'
 gem 'sequel_pg', :require=>'sequel'
 
 # Use Puma as the app server
@@ -41,6 +41,8 @@ gem 'newrelic_rpm'
 
 gem 'administrate', git: 'https://github.com/thoughtbot/administrate'
 gem 'administrate-field-jsonb'
+
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
+GIT
   remote: https://github.com/thoughtbot/administrate
   revision: 844c27091bab1a384b260a47b0a67dbff856640d
   specs:
@@ -154,7 +161,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -320,8 +326,9 @@ DEPENDENCIES
   jwt
   listen (>= 3.0.5, < 3.2)
   lograge
+  mimemagic!
   newrelic_rpm
-  pg
+  pg (= 1.1.4)
   pry
   puma (~> 3.11)
   pundit
@@ -344,4 +351,4 @@ RUBY VERSION
    ruby 2.6.4p104
 
 BUNDLED WITH
-   2.1.4
+   2.2.25

--- a/backend/db/migrate/20230111155424_remove_subdistricts_geojson_from_public_schools_analysis.rb
+++ b/backend/db/migrate/20230111155424_remove_subdistricts_geojson_from_public_schools_analysis.rb
@@ -1,0 +1,5 @@
+class RemoveSubdistrictsGeojsonFromPublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :public_schools_analyses, :subdistricts_geojson, foreign_key: true
+  end
+end

--- a/backend/db/migrate/20230111155439_add_subdistricts_geojson_ref_to_public_schools_analysis.rb
+++ b/backend/db/migrate/20230111155439_add_subdistricts_geojson_ref_to_public_schools_analysis.rb
@@ -1,0 +1,5 @@
+class AddSubdistrictsGeojsonRefToPublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :public_schools_analyses, :subdistricts_geojson, foreign_key: { on_delete: :cascade }
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_222225) do
+ActiveRecord::Schema.define(version: 2023_01_11_155439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -42,24 +42,8 @@ ActiveRecord::Schema.define(version: 2020_05_07_222225) do
     t.index ["user_id"], name: "index_project_permissions_on_user_id"
   end
 
-  create_table "projects", force: :cascade do |t|
-    t.text "name"
-    t.text "bbls", default: [], null: false, array: true
-    t.integer "build_year"
-    t.text "updated_by"
-    t.datetime "updated_at", null: false
-    t.datetime "created_at", null: false
-    t.integer "senior_units", default: 0, null: false
-    t.integer "total_units", default: 0, null: false
-    t.text "ceqr_number"
-    t.jsonb "commercial_land_use", default: [], null: false, array: true
-    t.jsonb "industrial_land_use", default: [], null: false, array: true
-    t.jsonb "community_facility_land_use", default: [], null: false, array: true
-    t.jsonb "parking_land_use", default: [], null: false, array: true
-    t.geometry "bbls_geom", limit: {:srid=>4326, :type=>"multi_polygon"}, null: false
-    t.integer "affordable_units", default: 0, null: false
-    t.bigint "data_package_id"
-  end
+# Could not dump table "projects" because of following StandardError
+#   Unknown type 'geometry(MultiPolygon,4326)' for column 'bbls_geom'
 
   create_table "public_schools_analyses", force: :cascade do |t|
     t.boolean "es_school_choice"
@@ -97,16 +81,8 @@ ActiveRecord::Schema.define(version: 2020_05_07_222225) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "transportation_analyses", force: :cascade do |t|
-    t.integer "traffic_zone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "project_id"
-    t.geometry "census_tracts_centroid", limit: {:srid=>4326, :type=>"st_point"}, null: false
-    t.text "required_census_tracts_selection", default: [], null: false, array: true
-    t.text "census_tracts_selection", default: [], array: true
-    t.text "modes_for_analysis", default: [], null: false, array: true
-  end
+# Could not dump table "transportation_analyses" because of following StandardError
+#   Unknown type 'geometry(Point,4326)' for column 'census_tracts_centroid'
 
   create_table "transportation_planning_factors", force: :cascade do |t|
     t.jsonb "mode_splits_from_user", default: {}, null: false
@@ -140,7 +116,7 @@ ActiveRecord::Schema.define(version: 2020_05_07_222225) do
   add_foreign_key "projects", "data_packages"
   add_foreign_key "public_schools_analyses", "data_packages"
   add_foreign_key "public_schools_analyses", "projects"
-  add_foreign_key "public_schools_analyses", "subdistricts_geojsons"
+  add_foreign_key "public_schools_analyses", "subdistricts_geojsons", on_delete: :cascade
   add_foreign_key "transportation_analyses", "projects"
   add_foreign_key "transportation_planning_factors", "data_packages"
   add_foreign_key "transportation_planning_factors", "transportation_analyses"


### PR DESCRIPTION
### Summary
Updated the schema reference for  `subdistricts_geojson` on the `public_schools_analysis` table to add `cascade: :delete` which should allow users to delete a project and all associated references to that project.

### Fixes 
[AB#11520](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/11520)