### PR TITLE
11520 schema updated to allow cascade delete on the subdistricts_geojson column

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2.1'
-gem 'pg'
+gem 'pg', '1.1.4'
 gem 'sequel_pg', :require=>'sequel'
 
 # Use Puma as the app server
@@ -41,6 +41,8 @@ gem 'newrelic_rpm'
 
 gem 'administrate', git: 'https://github.com/thoughtbot/administrate'
 gem 'administrate-field-jsonb'
+
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
+GIT
   remote: https://github.com/thoughtbot/administrate
   revision: 844c27091bab1a384b260a47b0a67dbff856640d
   specs:
@@ -154,7 +161,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -320,8 +326,9 @@ DEPENDENCIES
   jwt
   listen (>= 3.0.5, < 3.2)
   lograge
+  mimemagic!
   newrelic_rpm
-  pg
+  pg (= 1.1.4)
   pry
   puma (~> 3.11)
   pundit
@@ -344,4 +351,4 @@ RUBY VERSION
    ruby 2.6.4p104
 
 BUNDLED WITH
-   2.1.4
+   2.2.25

--- a/backend/db/migrate/20230113200807_remove_subdistricts_geojson_from_public_schools_analysis.rb
+++ b/backend/db/migrate/20230113200807_remove_subdistricts_geojson_from_public_schools_analysis.rb
@@ -1,0 +1,5 @@
+class RemoveSubdistrictsGeojsonFromPublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :public_schools_analyses, :subdistricts_geojson, foreign_key: true
+  end
+end

--- a/backend/db/migrate/20230113200811_add_subdistricts_geojson_ref_to_public_schools_analysis.rb
+++ b/backend/db/migrate/20230113200811_add_subdistricts_geojson_ref_to_public_schools_analysis.rb
@@ -1,0 +1,5 @@
+class AddSubdistrictsGeojsonRefToPublicSchoolsAnalysis < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :public_schools_analyses, :subdistricts_geojson, foreign_key: { on_delete: :cascade }
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_222225) do
+ActiveRecord::Schema.define(version: 2023_01_13_200811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 2020_05_07_222225) do
   add_foreign_key "projects", "data_packages"
   add_foreign_key "public_schools_analyses", "data_packages"
   add_foreign_key "public_schools_analyses", "projects"
-  add_foreign_key "public_schools_analyses", "subdistricts_geojsons"
+  add_foreign_key "public_schools_analyses", "subdistricts_geojsons", on_delete: :cascade
   add_foreign_key "transportation_analyses", "projects"
   add_foreign_key "transportation_planning_factors", "data_packages"
   add_foreign_key "transportation_planning_factors", "transportation_analyses"


### PR DESCRIPTION
### Summary
Updated the schema reference for  `subdistricts_geojson` on the `public_schools_analysis` table to add `cascade: :delete` which should allow users to delete a project and all associated references to that project.

### Fixes 
[AB#11520](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/11520)