### PR TITLE
4426 created migration to fix mispelled month in data packages

### DIFF
--- a/backend/db/migrate/20230124164916_fix2020_data_package_spelling.rb
+++ b/backend/db/migrate/20230124164916_fix2020_data_package_spelling.rb
@@ -1,0 +1,17 @@
+class Fix2020DataPackageSpelling < ActiveRecord::Migration[5.2]
+  def up
+    dataPackage = DataPackage.find_by(name: 'Februrary 2020')
+
+    dataPackage.update_attributes({
+      name: 'February 2020'
+    })
+  end
+
+  def down
+    dataPackage = DataPackage.find_by(name: 'February 2020')
+
+    dataPackage.update_attributes({
+      name: 'Februrary 2020'
+    })
+  end
+end


### PR DESCRIPTION
### Summary
Created migration to correct the spelling of February (from Februrary) in the data packages table.

### Fixes 
[AB#4426](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/4426)