### PR TITLE
12171 initial set of maintenance start and end times inteh netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,11 @@
 
 [context.master]
     command = "yarn build --environment=production"
+    environment = { HOST="https://ceqr-app-prod.herokuapp.com", MAINTENANCE_START='01/01/23 00:00', MAINTENANCE_END='01/01/23 00:00' }
 
 [context.deploy-preview]
     command = "yarn build --environment=review"
+    environment = { HOST="https://ceqr-app-staging.herokuapp.com", MAINTENANCE_START='02/02/23 00:00', MAINTENANCE_END='06/03/23 00:00' }
 
 # enable entry to app through routes other than /
 [[redirects]]


### PR DESCRIPTION
### Summary
Set up environment in the netlify.toml to set maintenance start and end times

### FIxes
[AB#12171](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/12171)