### PR TITLE
12171 turn on maintenance start and end times in the netlify.toml (#787)

### DIFF
--- a/frontend/app/templates/components/maintenance-notice.hbs
+++ b/frontend/app/templates/components/maintenance-notice.hbs
@@ -2,7 +2,7 @@
   <div class="ui maintenance-banner">
     <div class="maintenance-notice">
       <p>
-        Please be advised that there will be scheduled maintenance from {{this.maintenanceStart}} to {{this.maintenanceEnd}}. During that time, you will not be able to sign in to your account.  Thank you for your understanding. For help, please email CEQRApp@planning.nyc.gov.
+        Please be advised that there will be scheduled maintenance from {{this.maintenanceStart}} to {{this.maintenanceEnd}}. During that time, you may not be able to sign in to your account and/or possibly encounter errors using CEQR. We apologize for the inconvenience and thank you for your understanding. For help, please email CEQRApp@planning.nyc.gov.
       </p>
     </div>
   </div>
@@ -12,7 +12,7 @@
   <div class="ui maintenance-banner">
     <div class="maintenance-notice">
       <p>
-        Please be advised that we are currently performing scheduled maintenance from {{this.maintenanceStart}} to {{this.maintenanceEnd}}. During that time, you will not be able to sign in to your account.  Thank you for your understanding. For help, please email CEQRApp@planning.nyc.gov.
+        Please be advised that we are currently performing scheduled maintenance from {{this.maintenanceStart}} to {{this.maintenanceEnd}}. During that time, you may not be able to sign in to your account and/or possibly encounter errors using CEQR. We apologize for the inconvenience and thank you for your understanding. For help, please email CEQRApp@planning.nyc.gov.
       </p>
     </div>
   </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,11 @@
 
 [context.master]
     command = "yarn build --environment=production"
+    environment = { HOST="https://ceqr-app-prod.herokuapp.com", MAINTENANCE_START='02/06/23 11:00', MAINTENANCE_END='02/06/23 14:00' }
 
 [context.deploy-preview]
     command = "yarn build --environment=review"
+    environment = { HOST="https://ceqr-app-staging.herokuapp.com", MAINTENANCE_START='02/06/23 11:00', MAINTENANCE_END='02/06/23 14:00' }
 
 # enable entry to app through routes other than /
 [[redirects]]


### PR DESCRIPTION
#### Summary
merging develop to master to "turn on" maintenance flags for the upcoming migration(s) 